### PR TITLE
docs(articles): レビュー指摘を gemini-cli-github-actions-zenn-article に反映

### DIFF
--- a/articles/gemini-cli-github-actions-zenn-article.md
+++ b/articles/gemini-cli-github-actions-zenn-article.md
@@ -19,12 +19,12 @@ published: true
 
 ```mermaid
 graph LR;
-    dev["Dev pushes branch"] --> pr["GitHub PR / Issue"];
+    dev["開発者がpush"] --> pr["GitHub PR / Issue"];
     pr --> act["run-gemini-cli Action"];
-    act --> task{Task type?};
-    task -->|"/review"| review["AI comment (PR)"];
-    task -->|"/triage"| label["Label added"];
-    task -->|@gemini-cli| ondemand["On-demand reply"];
+    act --> task{タスク種別};
+    task -->|"/review"| review["PRへのAIコメント"];
+    task -->|"/triage"| label["ラベル付与"];
+    task -->|"@gemini-cli"| ondemand["オンデマンド応答"];
 ```
 
 > **図のポイント** — PR・Issue・コメントの3系統トリガーが一本化される。
@@ -34,8 +34,8 @@ graph LR;
 > **Gemini CLI Review (自動投稿例)**  
 > ```
 > ❌  N+1 クエリの可能性を検出:
->     Order.find({ include: 'items' })
->     ↳ 改善案: `Order.preload('items')`
+>     注文を1件ずつ取得したあと、各注文の items を個別にロードしています
+>     ↳ 改善案: 事前にプリロード（ORM のイーガーロード API を使用）
 >
 > 💡  変数名が抽象的です: `data`
 >     ↳ 目的に合わせて `orderSummary` など具体名へ


### PR DESCRIPTION
## Summary
\`reviews/gemini-cli-github-actions-zenn-article.md\` の指摘を \`articles/gemini-cli-github-actions-zenn-article.md\` に反映します。

> ⚠️ **公開済み記事** (\`published: true\`)
> 本PRは既にZenn上で公開されている記事への修正を含みます。マージ時に変更が反映されるため、文意が変わらないか最終レビューをお願いします。

## 採否一覧

### ✅ 採用 (2件)

| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 4 | L33-L48 (AIコメントサンプル) | N+1改善例のORM記法不整合 (Rails/JS混在、\`Order.find({ include: 'items' })\` はActiveRecord構文として不正) | 明確な技術的誤り。読者が誤ったAPIを学ぶリスクあり。抽象表現化で最小変更 |
| 8 | L18-L28 (Mermaid図) | 図ラベルが英語で、本文/図のポイント解説の日本語と不整合 | 客観的な可読性向上。記事全体の言語統一 |

### ⏸ 保留 (6件)

| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1 | L9-L14, L53 (数値訴求) | 「67%削減」「1/3短縮」の根拠記載なし | 根拠追記 or 表現緩和は著者の編集判断領域。読者訴求戦略に関わるため機械的変更は避ける |
| 2 | L79-L85 (最小3ワークフロー) | YAML実装例が「リポジトリに同梱」のみで本文内に無し | 記事を「概要重視」で構成するか「ハンズオン重視」かは著者方針。追記判断領域 |
| 3 | L63-L75 (失敗談) | \`/rollback-labels\` \`confidence_threshold\` が公式機能に見える | 指摘内容は妥当だが、提案は表全体の書き換えを含む。著者が注記の程度を判断するべき |
| 5 | L51-L59, L79-L85, L102-L107 (重複構成) | 「使いどころ」「最小3ワークフロー」「運用Tips」で類似情報が分散 | 構成変更は記事全体の設計判断領域。マッピング表化は大規模な再編を伴う |
| 6 | L91-L98 (\`GEMINI.md\`サンプル) | NG例・レビュー観点・コマンド定義が不足 | 内容追加は著者の知見共有方針に依存。機械的な追記は避ける |
| 7 | L119-L129 (自社メディア/関連記事順序) | まとめ後に宣伝ブロック2連、\`:::message\` 過多 | 宣伝配置は著者の編集方針。順序変更は意図を損なう可能性 |

### ❌ 却下 (0件)

## 変更内容
- Mermaid図のラベルを日本語に統一（図のポイント解説と言語一致）
- N+1改善例を特定ORMに依存しない抽象表現に変更（Rails ActiveRecord では \`Order.find({ include: ... })\` は不正な構文）

## 検証
- [ ] 採用分の差分目視（Mermaid描画確認、抽象表現の自然さ）
- [ ] 保留項目について、ご判断ください（追加反映が必要なものがあればコメントで指示）
- [ ] \`published: true\` 記事のため、Zenn公開ページと本PR差分を突き合わせる

## 関連
- レビュー元: \`reviews/gemini-cli-github-actions-zenn-article.md\`
- ワークフロー定義: PR #34 (\`.claude/\` 配下)

🤖 Generated with [Claude Code](https://claude.com/claude-code)