### PR TITLE
docs(articles): レビュー指摘を obsidian-supermemory-mcp に反映

### DIFF
--- a/articles/obsidian-supermemory-mcp.md
+++ b/articles/obsidian-supermemory-mcp.md
@@ -61,18 +61,18 @@ published: true
 | **ChatGPT Memory**  | ◎                     | ChatGPT 専用の記憶                           | ChatGPT 中心なら自然に利用可能             | 他クライアントと共有不可           |
 | **Mem.ai**          | ○                     | メモアプリ＋ AI                              | 個人メモ重視、UX に優れる                  | 開発ツール連携は弱め               |
 
-### 関連記事紹介
+### 関連記事
 
-「Serena と Cipher の比較」については、こちらの記事がとても参考になります。
-👉 [Serena vs Cipher 比較記事（Zenn: minewo さん）](https://zenn.dev/minewo/articles/serena-vs-cipher-comparison)
+Serena と Cipher の詳細比較は、別記事で整理しています。
 
-この記事では、
+👉 [2分で決まる：Serena vs Cipher　思想とアーキテクチャ](https://zenn.dev/minewo/articles/serena-vs-cipher-comparison)
+
+要点:
 
 - **Serena** は「Claude Code に特化した効率化」
 - **Cipher** は「OSS MCP サーバとしての永続メモリ」
 
-という住み分けが丁寧に解説されています。
-今回紹介する Supermemory MCP は、この 2 つの中間に位置する「手軽さ＋横断利用」が強みです。
+本記事の Supermemory MCP は、この 2 つの中間に位置する「手軽さ＋横断利用」が強みです。
 
 ---
 


### PR DESCRIPTION
## Summary
`reviews/obsidian-supermemory-mcp.md` の指摘を `articles/obsidian-supermemory-mcp.md` に反映します。

> ⚠️ **公開済み記事** (`published: true`)
> 本PRは既にZenn上で公開されている記事への修正を含みます。マージ時に変更が反映されるため、文意が変わらないか最終レビューをお願いします。

## 採否一覧

### ✅ 採用 (1件)
| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 1 | L64-L75 「関連記事紹介」 | 自著記事を「minewo さん」と三人称で紹介している箇所を、自著であることを示す表現に修正 | 同一著者の記事を他人の記事のように紹介することは読者の誤解を生む事実整合上の問題。軽微な表現差し替えで解消可能 |

### ⏸ 保留 (7件)
| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1 | L108-L113 Step2 コマンド例 | URL 取得方法・クライアント種別の明記、手動設定のフォールバック追記 | コンテンツ追加提案。著者判断領域 |
| 2 | L34 「100+ AI クライアント対応」 | 数字出典の明示または表現緩和 | Supermemory 公式表記に沿った既存記述。表現の好みで著者判断領域 |
| 3 | L52-L62 比較表 | 「MCP サーバ」と「ノートアプリ」で表を分離 | 構成変更提案。著者判断領域 |
| 4 | L56-L62 比較表「導入のしやすさ」 | 評価基準の明記 | 追記提案。著者判断領域 |
| 5 | L29 / L98 「個人開発」重複主張 | 「なぜ個人開発で特に効くのか」短章の追加 | 構成・追記提案。著者判断領域 |
| 6 | L7 frontmatter topics | 大文字・日本語タグの小文字化など | `published: true` のため安易な変更は避ける。Zenn は日本語タグも一定サポート。著者判断領域 |
| 7 | L123-L129 まとめ | Obsidian → Supermemory 連携の具体手順 (Step4) の追加 | 大きなコンテンツ追加提案。著者判断領域 |

### ❌ 却下 (0件)

## 変更内容
- L64-L75 の「関連記事紹介」節を「関連記事」に改題し、自著を率直に示す表現へ差し替え（他の段落は触っていません）。

## 検証
- [ ] 採用分の差分目視
- [ ] 保留項目の採否判断
- [ ] published: true 記事のため、Zenn公開ページと本PR差分の整合確認

## 関連
- レビュー元: `reviews/obsidian-supermemory-mcp.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)