### PR TITLE
docs(articles): レビュー指摘を design-md-guide-and-adoption-log に反映

### DIFF
--- a/articles/design-md-guide-and-adoption-log.md
+++ b/articles/design-md-guide-and-adoption-log.md
@@ -144,7 +144,7 @@ Figma や Penpot のようなデザインツールはもちろん必要です。
 
 共通の color、typography、spacing、radius は `common` に置き、公開側と管理画面側の差分だけを分離する構成です。
 
-Growth Lab は記事メディア中心のため `public/admin` 分割ではなく、`tokens -> primitives -> components -> article patterns -> page templates` の 5 層モデルで整理しています。この考え方は公開側のみのプロダクトにも応用しやすいです。
+Growth Lab は記事メディア中心のため `public/admin` 分割ではなく、**Tokens → Primitives → Components → Article Patterns → Page Templates** の 5 層モデルで整理しています。この考え方は公開側のみのプロダクトにも応用しやすいです。
 
 ```mermaid
 graph TD
@@ -363,15 +363,11 @@ Growth Lab の構成から見ても、つまずきやすい点はあります。
 
 ### 追記テンプレート
 
-- リポジトリ名:
-- 対象:
-- 導入時期:
-- 導入範囲:
-- 期待していた効果:
-- 実際の変化:
-- うまくいった点:
-- つまずいた点:
-- 次に直したい点:
+- Repository:
+- Scope:
+- Stage: (considering / adopting / adopted)
+- Outcome:
+- Notes:
 
 ## 最小導入の3ステップ
 
@@ -419,7 +415,7 @@ Growth Lab では、`DESIGN.md` を軽量な入口に絞り、詳細を関連ド
 
 ---
 
-## 【追加】DESIGN.md 導入のFAQ（2026-04-05追記）
+## DESIGN.md 導入のFAQ
 
 ### Q. DESIGN.md の導入はどのタイミングが最適？
 


### PR DESCRIPTION
## Summary
`reviews/design-md-guide-and-adoption-log.md` の指摘を `articles/design-md-guide-and-adoption-log.md` に反映します。

> ⚠️ **公開済み記事** (`published: true`)
> 本PRは既にZenn上で公開されている記事への修正を含みます。マージ時に変更が反映されるため、文意が変わらないか最終レビューをお願いします。

## 採否一覧

### ✅ 採用 (3件)
| # | 該当箇所 | 内容 | 反映理由 |
| - | - | - | - |
| 1 | L364-374 (追記テンプレート) | テンプレートの項目名を直前の表ヘッダ (Repository/Scope/Stage/Outcome/Notes) に統一 | 表ヘッダと追記テンプレートの項目名が一致せず、追記する読者が混乱する明白な不整合 |
| 2 | L147 (Mermaid 図前の本文) | 本文の `tokens -> primitives -> ...` を Mermaid 図と同じ表記 (Tokens → Primitives → Components → Article Patterns → Page Templates) に統一 | 本文と図で表記が揺れており、用語統一の観点で明白な改善 |
| 3 | L422 (FAQ 章見出し) | 見出しから「【追加】... (2026-04-05追記)」という編集記号を除去し、`## DESIGN.md 導入のFAQ` に変更 | 公開記事に内部メモ的な編集記号が残っており、明白な編集判断 |

### ⏸ 保留 (5件)
| # | 該当箇所 | 内容 | 保留理由 |
| - | - | - | - |
| 1 | L376-385 / L387-402 | 「最小導入の3ステップ」と「まずはここから始める」の重複章を統合 | 構成変更（章のマージ）は著者判断領域 |
| 2 | L43, L173, L262-266 ほか | `pnpm penpot:verify` の package.json サンプルや検証スクリプト骨子の追記提案 | 内部スクリプトの開示判断と追記内容の取捨選択は著者判断領域 |
| 3 | L11-14, L22-45, L47-59 | TL;DR / はじめに / DESIGN.md とは / なぜ必要か の導入4章の統合・圧縮 | 構成変更は著者の編集判断 |
| 4 | L198-203 (時系列の表) | 時期列を「v0.6.0 等」と「2026-03-22」で統一する形式に整える | 修正には実際のリリース日付（v0.6.0 等の年月日）の事実調査が必要で、レビュアーの提案内も `2025-XX-XX` のプレースホルダ。著者にしか確定できない |
| 5 | L422-442 (FAQ 章) | FAQ を「まとめ」直前へ移動し、本文の重複章と統合する構成変更 | 章順や統合方針は著者の編集判断（編集記号の除去のみ採用、移動・統合は保留） |

### ❌ 却下 (0件)
なし

## 変更内容
- 追記テンプレートの項目名を表ヘッダに合わせて統一
- 本文の Tokens → Primitives → ... 表記を Mermaid 図と一致させる
- FAQ 見出しから【追加】編集記号を除去

## 検証
- [ ] 採用分の差分目視
- [ ] 保留項目の採否判断
- [ ] `published: true` 記事のため、Zenn公開ページと本PR差分の整合確認

## 関連
- レビュー元: `reviews/design-md-guide-and-adoption-log.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)