### PR TITLE
feat(qiita): Qiita記事を Qiita/public/ 配下で管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 *Zone.Identifier
+
+# Qiita CLI internal cache of remote state
+Qiita/public/.remote/

--- a/Qiita/public/2ee39ebf0711609c34c3.md
+++ b/Qiita/public/2ee39ebf0711609c34c3.md
@@ -1,0 +1,55 @@
+---
+title: REALFORCE(Windows)をMacBookで使う
+tags:
+  - Keyboard
+  - MacBook
+  - Karabiner-Elements
+  - realforce
+  - USB-Keyboard
+private: false
+updated_at: '2022-10-31T19:08:48+09:00'
+id: 2ee39ebf0711609c34c3
+organization_url_name: null
+slide: false
+ignorePublish: false
+---
+
+Windows専用のキーボードをGetしたので、MacBookユーザーに向けてキーボードのマッピングを紹介します。
+
+Macで快適に使うために、「Karabiner-Elements」で僕が設定している、カスタマイズ設定を紹介します。
+
+# MacBookでRealforceを使うなら「Karabiner-Elements」がオススメ
+
+Windows専用のキーボードは、Macとはキー配列が違うので接続しても使えないキーがあり、何かと不便なのです。
+
+そこで使うのmacOSから使うときにはキーマップ変更ソフト
+　**[Karabiner-Elements](https://karabiner-elements.pqrs.org/)** 
+がオススメです。
+
+この **Karabiner-Elements** を使いキーボードのマッピングを変更することで、より快適なキーボードになってきます。
+これを使わないと **「無変換」「変換」「半角/全角」** のキーで入力の変換が出来ないことになり、とっても不自由なキーボードとなってしまうのです。
+
+
+## 「Karabiner-Elements」の設定を行う
+![image.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/86428/0c1c212d-c297-bf31-54d7-9799c2969308.png)
+
+***
+
+## 東プレ「REALFORCE」のキーマップ変更内容
+| From key   | To key       |
+|:-----------|:------------:|
+|caps_lock	|left_control
+|PCキーボードのかなキー	|right_command
+|PCキーボードの無変換キー	|英数キー
+|PCキーボードの変換キー	|かなキー
+|left_alt	|left_command
+|left_command	|left_option
+|left_control	|left_command
+
+
+### 新しくREALFORCEを購入したときは
+現在はMac配列のREALFORCEが販売されているので、最初から「REALFORCE for Mac」を買うのがオススメです(笑)
+
+自分が初めて **REALFORCE** を購入したときは、Mac版は無かったですし、無線タイプのREALFORCEもありませんでした。
+
+改めて、

--- a/Qiita/public/5b137960d2e1c8f64ee9.md
+++ b/Qiita/public/5b137960d2e1c8f64ee9.md
@@ -1,0 +1,33 @@
+---
+title: '【brew】「Error: Unknown command: cask」ってでるよね'
+tags:
+  - brew
+  - brew-cask
+private: false
+updated_at: '2021-12-27T15:10:06+09:00'
+id: 5b137960d2e1c8f64ee9
+organization_url_name: null
+slide: false
+ignorePublish: false
+---
+久しぶりにbrewコマンドを使用したところ、brew caskが以下のエラーで通らなくなってしまいました。
+```Error: Unknown command: cask
+```
+
+以前は使用できていたはずなのに何故だろうと思い、調べました。
+
+##結論から言うと brew cask install は廃止された
+caskの使い方を
+```brew install XXXXX --cask
+```
+と変更すれば良かった。
+
+
+##まとめると
+caskコマンドの使い方が変更になった 
+
+```
+旧) $ brew cask install xxx
+↓
+新) $ brew install xxx --cask
+```

--- a/Qiita/public/842fc63efee66158af7d.md
+++ b/Qiita/public/842fc63efee66158af7d.md
@@ -1,0 +1,60 @@
+---
+title: ThinkPad TrackPoint Keyboard II (JIS配列）をMacBookで使う
+tags:
+  - thinkpad
+  - Keyboard
+  - MacBook
+  - Karabiner-Elements
+  - USB-Keyboard
+private: false
+updated_at: '2022-10-31T19:07:33+09:00'
+id: 842fc63efee66158af7d
+organization_url_name: null
+slide: false
+ignorePublish: false
+---
+ThinkPad TrackPoint Keyboard IIを新しく購入したので、MacBookユーザーに向けてキーボードのマッピングを紹介します。
+
+ThinkPad トラックポイント・キーボードを、macOSから使用しようとすると、
+　**[Karabiner-Elements](https://karabiner-elements.pqrs.org/)** 
+を使う必要があります。
+
+この Karabiner-Elements を使いキーボードのマッピングを変更することで、より快適なキーボードになってきます。
+これを使わないと **「無変換」「変換」「半角/全角」** のキーで入力の変換が出来ないことになり、とっても不自由なキーボードとなってしまうのです。
+
+これからの説明は
+　**ThinkPad TrackPoint Keyboard II**
+に合わせた説明で自分の備忘録を兼ねているので、くどい表現があったらすみません。
+
+「ThinkPad TrackPoint Keyboard II」はUSBでの接続とBluetooth接続が可能で、Bluetooth接続の場合はキーボードとマウスが1デバイスとして認識されるので、少し設定が変わります。
+
+自分は **Macbook Pro** とはUSB接続なので、トラックポイントのボタンの設定とキーボードは別デバイスとして設定をしています。
+
+日本語入力は「無変換」「変換」で単体押しで切り替えられるようにしてます。
+
+
+| From key   | To key       |
+|:-----------|:------------:|
+|international5: |無変換キー|
+|international4: |変換キー|
+|international2: |カタカナひらがなキー|
+|lang2: |macの英数キー|
+|lang1: |macのかなキー|
+
+ThinkpadキーボードのAltも、macの英数キーにマッピングしてます。
+
+![image.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/86428/e6b3577a-5221-4e2d-2032-a44fce94dc75.png)
+
+
+次に**センターボタン**によるスクロールを有効にする為の設定をします。
+※これをやっておかないと、トラックポイントでスクロールしようとしたときにセンターボタンでリンクをクリックすると、新しいウィンドウが開いてしまうということが。。。。
+
+ [https://pqrs.org/osx/karabiner/complex_modifications/] から「Change mouse motion to scroll (rev 1)」をKarabiner Elementsにインポートし、「Change button4 + mouse motion to scroll wheel (rev 1)」を有効にします。
+
+![image.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/86428/2768df92-317e-05d7-6e91-4129a584604d.png)
+
+最後にSimple ModificationsタブでThinkPadキーボードのマウスデバイス側で「button3」を「button4」にマッピングします。
+
+![image.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/86428/b9f0e90a-3abd-b773-1a69-eeaa74e3c81a.png)
+
+上記の設定をすることで、**ThinkPad TrackPoint Keyboard II** を **MacBook Pro** のキーボードを使うときの違和感が少なくなり、MacBook本体とThinkpadキーボードを切り替えながら使っても近い感覚で使えるようになりました。

--- a/Qiita/public/8e4515d5f30cfe45af32.md
+++ b/Qiita/public/8e4515d5f30cfe45af32.md
@@ -1,0 +1,164 @@
+---
+title: nodeでスクレイピングをしたのでライブラリ「CasperJS」と「cheerio-httpcli」の紹介
+tags:
+  - Node.js
+  - スクレイピング
+  - casperJs
+  - テスト自動化
+  - cheerio-httpcli
+private: false
+updated_at: '2017-12-25T10:06:00+09:00'
+id: 8e4515d5f30cfe45af32
+organization_url_name: null
+slide: false
+ignorePublish: false
+---
+
+[フロムスクラッチ Advent Calendar 2017](https://qiita.com/advent-calendar/2017/fromscratch) の19日目の記事です。
+
+# はじめに
+WEBサイトの情報を定期的に取得したいときってありますよね。
+しかも、広大なサイト内の情報を定期的に、、、指定文字を検索するとか、色々とWEBサイトを巡回して自動化したいという要望に答えるべく、プログラムを書きます。
+
+WEBサイトからデータ取得する時に必要な技術要素は、「**スクレイピング**」ですね。
+
+スクレイピングとは
+> ウェブスクレイピング（Web scraping）とは、ウェブサイトから情報を抽出するコンピュータソフトウェア技術のこと。ウェブ・クローラー(Web crawler) あるいはウェブ・スパイダー(Web spider)とも呼ばれる。
+[ウェブスクレイピング](http://ja.wikipedia.org/wiki/%E3%82%A6%E3%82%A7%E3%83%96%E3%82%B9%E3%82%AF%E3%83%AC%E3%82%A4%E3%83%94%E3%83%B3%E3%82%B0) – Wikipediaより 
+
+強力なクローリング・スクレイピングフレームワークのScrapy（python）など、有名ですが、今回は気軽にサクサク作れるnodeで作ってみました。
+
+目標は取得したいURLは別で用意しているので、そこからスタート！
+#nodeでスクレイピングをしたのでライブラリの紹介#
+
+#今回のターゲットは「**CasperJS**」と「**cheerio-httpcli**」
+
+##この２つを簡単に紹介##
+###『cheerio-httpcli』の説明###
+cheerioはHTMLパーサに jQuery API のサブセットを実装したものです。
+DOM APIはありません。必ずjQueryの関数を使う必要があります。
+*→静的なHTMLをベースに処理するモジュールなのでSPAなどクライアントサイドのJavaScriptによってコンテンツを取得/変更するタイプのWEBページには対応していません。*
+
+↓github
+https://github.com/ktty1220/cheerio-httpcli
+
+###『CasperJS』の説明###
+phantomjs という Javascript で動かせるヘッドレスブラウザと casperjs というユーティリティを使って動かすという感じです。
+*PhantomJS のレンダリングエンジンには Webkit が使われています*
+*CasperJS は、その PhantomJS をより手軽に使えるようにするライブラリです*
+*casperJSはphantomJSがないと動きません。*
+
+↓github
+https://github.com/casperjs/casperjs
+↓公式サイト
+http://casperjs.org/
+↓公式APIドキメント
+http://docs.casperjs.org/en/latest/modules/index.html
+
+##この２つを選んだ理由と使い分け##
+###『cheerio-httpcli』を選んだ理由###
+####jQueryに慣れている場合は、学習コストが低く済むハズ。####
+今まで使っていた『jQuery』をサーバーでサイドで使えるとは、使ってみるしか無いでしょ。
+***確実に、工数削減に繋がったハズ***
+
+####プロキシサーバー経由でアクセスの設定標準で用意されている####
+AWSでサーバーを用意すると、そのIP帯からのアクセスをブロックしているサイトがあるので、プロキシを経由するなどの対策が取りやすいので、この対応が出来るライブラリを選出
+
+####User-Agentを手動で設定出来る####
+スマートフォンサイト、PCTサイト、タブレットサイトで表示形態が異なる事があるので、UAを個別にしてい出来ると確認がし易いので、運用上ここも重要なポイント
+
+####受信するデータの限界量を数値(バイト数)で指定出来る####
+このライブラリの目的はHTMLをサックっと取得して、さくっと抽出するという軽い処理を並行で実施したいので、大きいサイズのページとかはエラーでスキップしたいので、これもポイント高い！
+
+####同期処理、非同期処理用の関数が用意されている####
+今回は使わなかったが、同期処理と非同期処理の関数が用意されているので、対象ページに寄って同期・非同期を分けるなどがし易くなるハズ
+*※ここは将来の拡張性の話*
+
+###『CasperJS』の説明###
+phantomjs という Javascript で動かせるヘッドレスブラウザと casperjs というユーティリティを使って動かすという使い方が多いです。
+####PhantomJSを使ってブラウザなしでWebページを表示・実行できる####
+『PhantomJS』は、
+
+- Webkitベースのヘッドレスで高速なブラウザ
+- ヘッドレスとはGUIを持たないという意味で、完全にCUIでのみ動作
+- CanvasやSVGなどもサポートされていて、画像を出力する事も可能
+
+なので、ajaxを使った表示にも対応出来るのでクライアントサイドのJavaScriptによってコンテンツを取得/変更するタイプのWEBページにも対応ができる
+
+####PhantomJSを使ってスクリーンキャプチャを自動化が可能####
+PhantomJSはコマンドラインから実行するWEBブラウザで、ヘッドレスブラウザ(GUIがないコマンドライン用のブラウザ)なので、レンダリングした後のキャプチャを撮ることができる
+
+####エンジンを PhantomJS 以外に出来る####
+ - phantomjs : Chrome系エンジン
+ - slimerjs : Firefox系エンジン
+ - triflejs : IE系エンジン
+
+####CasperJSはCoffeeScriptも実行可能####
+*※ここは将来の拡張性の話*
+
+## 導入&サンプル ##
+### cheerio-httpcli導入編 ###
+```
+sudo npm install cheerio-httpcli
+```
+一応上記のコマンドについて補足すると、cheerio-httpcliをグローバルにインストールしています。
+
+### cheerio-httpcliサンプル ###
+```cheerio.js
+var client = require('cheerio-httpcli');
+var TARGET ="https://bdash-marketing.com/";
+
+client.fetch(TARGET , (err, $, res) => {
+    const result = [];
+    $('.normal_list').each(function (id, el) {
+        const month = $(this).find('#home-section-header').text();
+
+        $(this).find('li').each(function (id, el) {
+            result.push(month + $(this).text().replace(/\r?\n?/g, ''));
+        });
+    });
+
+    console.log(result.join('\n'));
+});
+
+```
+
+
+### CasperJS導入編 ###
+CasperJSのインストール　[公式サイト](http://casperjs.org)からダウンロードできます。
+
+```
+sudo npm install -g phantomjs
+sudo npm install -g casperjs
+```
+一応上記のコマンドについて補足すると、PhantomJSとCasperJSをグローバルにインストールしています。
+### CasperJS サンプル ###
+`gethtml.js` を用意
+
+```gethtml.js
+var casper = require('casper').create();
+var fs = require('fs');
+var $  = require('jquery');
+var FILE_NAME = "output.html";
+var TARGET ="https://bdash-marketing.com/";
+var outs =[];
+
+casper.start(TARGET, function(){
+  // id="home-section-header"のコンテンツを取得する
+  var t = this.getHTML("#home-section-header");
+  // jqueryオブジェクト化してリンクを取得する
+  $(t).find("a").each(function(){
+      outs.push($(this).prop('outerHTML')+"\r\n");
+  });
+});
+
+casper.then(function(){
+  // 取得したリンクリストをファイル出力
+  fs.write(FILE_NAME, outs.join(""));
+});
+
+casper.run();
+```
+
+`casperjs gethtml.js` で実行
+`output.html` を確認する

--- a/Qiita/public/95d1338d4c85e9303584.md
+++ b/Qiita/public/95d1338d4c85e9303584.md
@@ -1,0 +1,41 @@
+---
+title: エラー「Calling brew cask install is disabled!」が出たよ
+tags:
+  - homebrew
+  - 開発環境
+  - brew
+  - brew-cask
+  - cask
+private: false
+updated_at: '2021-01-01T03:45:52+09:00'
+id: 95d1338d4c85e9303584
+organization_url_name: null
+slide: false
+ignorePublish: false
+---
+homebrewでGUIをもつアプリをインストールしたい時はcaskを使いましたが、エラーが出る様になりました。
+
+`brew cask` コマンドは
+ - **2.6** から非推奨になり
+ - **2.7** から無効化されたようです。
+ - **2.8** からはエラーメッセージも表示されなくなるそうです。
+
+自分の環境は2.7.1でした。
+
+```
+brew --version
+Homebrew 2.7.1
+Homebrew/homebrew-core (git revision 30e7e; last commit 2020-12-31)
+Homebrew/homebrew-cask (git revision 88964b; last commit 2020-12-31)
+``` 
+
+#解決方法
+`brew cask install ~` を `brew install --cask ~` を替えれば実行出来ます。
+
+エラーをちゃんと確認してみると、、、、、、
+`Error: Calling brew cask install is disabled! Use brew install [--cask] instead.`
+
+エラーの内容の後に、ちゃんと書いてあった。
+`brew cask install` は無効だよ。 `--cask` を使うようにと。
+
+

--- a/Qiita/public/ai-dev-team-2025-retrospective.md
+++ b/Qiita/public/ai-dev-team-2025-retrospective.md
@@ -1,16 +1,16 @@
 ---
-title: "2025年、AIコーディングエージェントをチーム開発に入れてわかったこと"
+title: 2025年、AIコーディングエージェントをチーム開発に入れてわかったこと
 tags:
-  - AI駆動開発
-  - 生成AI
-  - チーム開発
   - アジャイル
-private: false
-updated_at: ""
-id: null
+  - チーム開発
+  - 生成AI
+  - AI駆動開発
+private: true
+updated_at: '2026-04-16T06:32:42+09:00'
+id: 0a43ef1991769fc07ae8
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
 
 <!--

--- a/Qiita/public/ai-dev-team-reviewable-ai-changes.md
+++ b/Qiita/public/ai-dev-team-reviewable-ai-changes.md
@@ -1,16 +1,16 @@
 ---
-title: "AIが書いたコードをレビュー可能にするために、先に決めておくこと"
+title: AIが書いたコードをレビュー可能にするために、先に決めておくこと
 tags:
-  - AI駆動開発
-  - 生成AI
   - チーム開発
   - コードレビュー
-private: false
-updated_at: ""
-id: null
+  - 生成AI
+  - AI駆動開発
+private: true
+updated_at: '2026-04-16T06:37:15+09:00'
+id: 3ed2cb58d22ac41fe2e1
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
 
 <!--

--- a/Qiita/public/ai-dev-team-test-first-agent-workflow.md
+++ b/Qiita/public/ai-dev-team-test-first-agent-workflow.md
@@ -1,16 +1,16 @@
 ---
-title: "AIに実装させる前にテスト観点を書くと、チーム開発がかなり安定した"
+title: AIに実装させる前にテスト観点を書くと、チーム開発がかなり安定した
 tags:
-  - AI駆動開発
-  - 生成AI
-  - テスト
   - TDD
-private: false
-updated_at: ""
-id: null
+  - テスト
+  - 生成AI
+  - AI駆動開発
+private: true
+updated_at: '2026-04-16T06:37:15+09:00'
+id: fd5e5642efb40bfe4198
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
 
 <!--

--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ Zenn と Qiita の記事をこのリポジトリで管理します。
 
 ## Qiita
 
-- 記事: `public/*.md`
+- 記事: `Qiita/public/*.md`
 - プレビュー: `npm run preview:qiita`
 - 新規作成: `npm run new:qiita -- article-base-name`
 - Qiita から取得: `npm run pull:qiita`
 - 1記事を投稿・更新: `npm run publish:qiita -- article-base-name`
 - 全記事を投稿・更新: `npm run publish:qiita:all`
 
-Qiita CLI は `public` ディレクトリ配下の Markdown を記事として扱います。
+Qiita CLI は `<root>/public/` 配下の Markdown を記事として扱います。本リポジトリでは `--root Qiita` を指定しているため、実体は `Qiita/public/` です。
 公開前の下書きは Front Matter の `ignorePublish: true` を維持してください。
 
 ## Qiita イベントメモ
 
 次の3本は、Qiita 公式イベント「2025年、生成AIを使ってみてどうだった？」向けに検討を始めたドラフトです。
 
-- `public/ai-dev-team-2025-retrospective.md`
-- `public/ai-dev-team-reviewable-ai-changes.md`
-- `public/ai-dev-team-test-first-agent-workflow.md`
+- `Qiita/public/ai-dev-team-2025-retrospective.md`
+- `Qiita/public/ai-dev-team-reviewable-ai-changes.md`
+- `Qiita/public/ai-dev-team-test-first-agent-workflow.md`
 
 2026-04-13 時点で募集期間 `2026-01-19` から `2026-02-27` は終了しているため、いま投稿してもキャンペーン選考対象にはなりません。通常記事として公開する場合は、`ignorePublish: false` に変更する前に、キャンペーンタグを付けない方針で内容とタグを確認してください。
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "scripts": {
     "preview": "zenn preview",
-    "preview:qiita": "qiita preview",
+    "preview:qiita": "qiita preview --root Qiita",
     "list:articles": "zenn list:articles",
     "list:books": "zenn list:books",
-    "new:qiita": "qiita new",
-    "pull:qiita": "qiita pull",
-    "publish:qiita": "qiita publish",
-    "publish:qiita:all": "qiita publish --all",
+    "new:qiita": "qiita new --root Qiita",
+    "pull:qiita": "qiita pull --root Qiita",
+    "publish:qiita": "qiita publish --root Qiita",
+    "publish:qiita:all": "qiita publish --all --root Qiita",
     "check:qiita": "qiita version",
     "check": "npm run list:articles && npm run list:books && npm run check:qiita"
   },


### PR DESCRIPTION
## Summary

- Qiita CLI の運用ディレクトリを `public/` からリポジトリ直下の `Qiita/public/` に変更（Zenn の `articles/` と並列に配置し、スコープを明確化）
- `package.json` の Qiita 関連スクリプトに `--root Qiita` を付与
- `README.md` のパス記述を `Qiita/public/*.md` に更新
- `.gitignore` に `Qiita/public/.remote/`（CLI の内部キャッシュ）を追加
- ai-dev-team ドラフト3本を限定共有記事として Qiita に投稿済み（`private: true`, `ignorePublish: false`、id 付与）

## Test plan

- [ ] `npm run preview:qiita` が `Qiita/public/` 配下の記事を表示する
- [ ] `npm run pull:qiita` がエラーなく完了する
- [ ] `npm run publish:qiita -- <slug>` で記事更新が反映される
- [ ] README の手順で新規メンバーが迷わずセットアップできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)