### PR TITLE
feat(note): md_to_wxr.py に --base-url オプションを追加

### DIFF
--- a/.claude/skills/note-export-import/scripts/md_to_wxr.py
+++ b/.claude/skills/note-export-import/scripts/md_to_wxr.py
@@ -4,17 +4,20 @@
 使い方:
     python3 md_to_wxr.py articles_note/new/<slug>.md [--out articles_note/build/<slug>.xml]
     python3 md_to_wxr.py articles_note/new/                # ディレクトリを指定すると全MDを一括変換
+    python3 md_to_wxr.py ... --base-url https://raw.githubusercontent.com/OWNER/REPO/main/articles_note/assets/
 
 処理内容:
     - 先頭 "# タイトル" を title に、それ以降を本文として扱う
     - "> 出典:" "> 公開状態:" 等のメタ行は本文から除外
     - Markdown → HTML を python-markdown で変換
     - WXR 1ファイル=1記事 を出力（複数指定時はまとめたWXRを1本生成）
-    - ローカル画像 (`../assets/...`, `assets/...`, 相対パス) を検出して警告
+    - --base-url 指定時: `../assets/<file>` `assets/<file>` の画像参照を
+      `<base_url>/<file>` に書き換えて note に自動取り込みできる形にする
+    - --base-url 未指定時: ローカル画像パスは残したまま警告のみ
 
 note制約:
     - インポートは新規下書きとして取り込まれる
-    - 画像は <img src="https://..."> でないと自動取り込みされない
+    - 画像は <img src="https://..."> (JPEG/PNG/GIF) でないと自動取り込みされない
 """
 from __future__ import annotations
 import argparse
@@ -33,6 +36,7 @@ except ImportError:
 
 META_LINE_RE = re.compile(r"^>\s*(?:出典|公開状態|更新|区分)\s*[:：]", re.MULTILINE)
 LOCAL_IMG_RE = re.compile(r'!\[[^\]]*\]\((?!https?://|data:)[^)]+\)')
+ASSET_IMG_RE = re.compile(r'(!\[[^\]]*\]\()(?:\.\./)?assets/([^)]+)\)')
 
 
 def split_front(text: str) -> tuple[str, str]:
@@ -53,18 +57,31 @@ def split_front(text: str) -> tuple[str, str]:
 def warn_local_images(path: Path, body: str) -> None:
     hits = LOCAL_IMG_RE.findall(body)
     if hits:
-        sys.stderr.write(f"[warn] {path.name}: ローカル画像 {len(hits)}件あり。インポート後にnoteエディタで貼り直してください:\n")
+        sys.stderr.write(f"[warn] {path.name}: ローカル画像 {len(hits)}件あり。--base-url で絶対URLに書き換えるか、インポート後にnoteエディタで貼り直してください:\n")
         for h in hits[:5]:
             sys.stderr.write(f"   - {h}\n")
         if len(hits) > 5:
             sys.stderr.write(f"   ...他 {len(hits)-5} 件\n")
 
 
-def render_item(md_path: Path) -> str:
+def rewrite_assets_to_url(body: str, base_url: str) -> tuple[str, int]:
+    base = base_url.rstrip("/") + "/"
+    count = [0]
+    def sub(m):
+        count[0] += 1
+        return f"{m.group(1)}{base}{m.group(2)})"
+    return ASSET_IMG_RE.sub(sub, body), count[0]
+
+
+def render_item(md_path: Path, base_url: str | None = None) -> str:
     text = md_path.read_text()
     title, body_md = split_front(text)
     if not title:
         title = md_path.stem
+    if base_url:
+        body_md, rewritten = rewrite_assets_to_url(body_md, base_url)
+        if rewritten:
+            sys.stderr.write(f"[ok] {md_path.name}: {rewritten}件の画像パスを {base_url} に書き換え\n")
     warn_local_images(md_path, body_md)
     html = md.markdown(body_md, extensions=["fenced_code", "tables", "sane_lists"])
     now = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
@@ -124,13 +141,14 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("src", type=Path, help="MDファイルまたはディレクトリ")
     ap.add_argument("--out", type=Path, help="出力先WXR (省略時: articles_note/build/<name>.xml)")
+    ap.add_argument("--base-url", help="assets/ 参照を絶対URLに書き換える (例: https://raw.githubusercontent.com/OWNER/REPO/main/articles_note/assets)")
     args = ap.parse_args()
 
     inputs = collect_inputs(args.src)
     if not inputs:
         raise SystemExit(f"No .md found under {args.src}")
 
-    items = "".join(render_item(p) for p in inputs)
+    items = "".join(render_item(p, args.base_url) for p in inputs)
     xml = WRAPPER_HEAD + items + WRAPPER_TAIL
 
     if args.out:


### PR DESCRIPTION
## Summary

note インポート用 WXR 生成スクリプト `md_to_wxr.py` に `--base-url` オプションを追加。ローカル画像参照を絶対 URL に書き換えて、note インポート時の自動画像取り込みを可能にする。

## 動機

note のインポート仕様では `<img src=\"https://...\">` のみ自動取り込みされ、ローカル相対パス（`../assets/foo.png` 等）は取り込まれない。従来は WXR 生成後にすべての画像を note エディタで手動貼り直す必要があった。

GitHub Raw などに画像を公開配置している運用なら、WXR 生成時に絶対 URL へ書き換えれば自動取り込みが効く。

## 変更点

- `--base-url` 引数を追加
- 新規の正規表現 `ASSET_IMG_RE` で `![...](../assets/<file>)` / `![...](assets/<file>)` をマッチ
- `--base-url` 指定時: これらを `![...](<base_url>/<file>)` に書き換え
- `--base-url` 未指定時: 従来どおりローカル参照を残して警告のみ
- help テキスト・警告メッセージを更新

## 使い方

```bash
# 自動取り込みを効かせる（画像が GitHub Raw 等に公開されている前提）
python3 .claude/skills/note-export-import/scripts/md_to_wxr.py \
  articles_note/new/<slug>.md \
  --base-url https://raw.githubusercontent.com/s977043/my-blog/main/articles_note/assets

# 従来どおり（手動貼り直し前提）
python3 .claude/skills/note-export-import/scripts/md_to_wxr.py articles_note/new/<slug>.md
```

## Test plan

- [x] `python3 -m ast .../md_to_wxr.py` 構文 OK
- [x] `--help` に `--base-url` が表示される
- [ ] `--base-url` 指定で assets 参照が書き換わる（ユーザー環境で実走確認）
- [ ] 未指定時は従来動作（警告のみ、本文無変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)