### PR TITLE
chore(gitignore): .claude/scheduled_tasks.lock を除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ articles_note/build/
 
 # ローカルエージェントツールのミラーキャッシュ (再生成可能)
 .agents/
+
+# Claude Code スケジュール実行の排他ロック (ランタイム生成)
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
Claude Code の ScheduleWakeup 機能が生成するランタイム排他ロックファイル `.claude/scheduled_tasks.lock` を `.gitignore` に追加。コミット対象外とする。

## Test plan
- [x] `git status` でロックファイルが untracked から ignored に変わること
- [ ] CI: Content checks 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)