### PR TITLE
docs(articles): ai-generated-skill-md-reality-check のレビュー反映（採用 3 / 保留 5 / 却下 0）

### DIFF
--- a/articles/ai-generated-skill-md-reality-check.md
+++ b/articles/ai-generated-skill-md-reality-check.md
@@ -71,7 +71,7 @@ AI に「このスキルを説明して」と頼むと、機能の **理想像**
 
 ### 仮説 3: 設計者も SKILL.md と実装が一致しているか確認していない
 
-AI が生成した SKILL.md を読み、AI が生成したスクリプトを採用して、誰もシンクさせていない。
+AI が生成した SKILL.md を読み、AI が生成したスクリプトを採用して、誰も両者の整合を取っていない。
 
 ## ズレを検知する方法
 
@@ -111,7 +111,7 @@ ls engineer_profiles/some_user/
 ```bash
 # LLM 呼び出しの痕跡を幅広く探す（Claude CLI / Anthropic SDK / OpenAI SDK / Gemini）
 grep -rEi \
-  "claude +-p|curl.*(anthropic|openai|generativelanguage)|anthropic-ai/sdk|import +Anthropic|from +anthropic|import +openai|from +openai|google-generativeai" \
+  "claude +(-p|--print)|curl.*(anthropic|openai|generativelanguage)|anthropic-ai/sdk|import +Anthropic|from +anthropic|import +openai|from +openai|google-generativeai" \
   scripts/
 ```
 
@@ -138,7 +138,7 @@ grep -rEi \
 - メリット: 実装と claim が一致する、運用として現実的
 - デメリット: 毎回手動で LLM を呼ぶ必要がある
 
-採用したのは **C** でした。SKILL.md を書き換えて「raw data 取得はスクリプト、分析はLLM側で行う」と明示。運用時は `raw_data/*.json` を Claude に読み込ませて、観点別に抽出プロンプトを投げる流れに。
+採用したのは **C** でした。SKILL.md を書き換えて「raw data 取得はスクリプト、分析は LLM 側で行う」と明示。運用時は `raw_data/*.json` を Claude に読み込ませて、観点別に抽出プロンプトを投げる流れに。
 
 ## AI 生成ドキュメントとの付き合い方
 


### PR DESCRIPTION
## Summary
`reviews/zenn/ai-generated-skill-md-reality-check.md`（2026-04-20 再レビュー、PR #91 で生成）の 8 件の指摘を `articles/ai-generated-skill-md-reality-check.md` に選別反映します。

> ⚠️ **公開済み記事** (`published: true`)
> 本PRは既に Zenn 上で公開されている記事への修正を含みます。マージ時に変更が反映されるため、文意が変わらないか最終レビューをお願いします。

> 補足: 既存ブランチ `chore/apply-review-ai-generated-skill-md-reality-check`（PR #82 でマージ済み）との衝突を避けるため、本 PR のブランチは `-r2` サフィックスを付与しています。

## 採否一覧

### 採用（3 件）

| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 1 | L141 | `LLM側` → `LLM 側`（日本語と英数字間の半角スペース） | 記事内他箇所（`LLM 呼び出し` L70/L82/L112）と表記統一。客観的な揺れ修正 |
| 5-2 | L114 | grep パターン `claude +-p` → `claude +(-p|--print)` | Claude CLI の長オプション `--print` の取りこぼしという技術的事実の修正。[Claude Code CLI docs](https://docs.claude.com/en/docs/claude-code/cli-reference) では `-p` と `--print` が同義 |
| 8-a | L74 | 「シンク」 → 「両者の整合を取って」 | 記事内の他の表現（和語ベース）との整合。カタカナ技術用語の唐突さを解消 |

### 保留（5 件、該当箇所 8 件中の残余）

| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1-b | L58 | `claim` 初出本文での日本語副題再掲 | L12 冒頭 message で定義済み。再掲の要否は著者判断。トーン・文章のリズムに影響 |
| 2 | L42-L54 | 「スクリプトを grep してみると」→「抜粋すると」＋コードブロック内コメントで 2 パート明示 | 地の文/コードブロックの書き方の好み。現行でも読解可能。構造的な書き換え |
| 3 | L143-L161 | 「付き合い方」4 点と「まとめ」4 点の重複圧縮（姉妹記事パターンへの寄せ） | 段落構成変更。著者のまとめ方針に属する編集判断。致命的な冗長ではない |
| 4 | L152 / L161 | 「1 次情報に戻る癖」「AI 協働時代」の硬い表現の柔らかい言い換え | トーン調整。「1 次情報」は著者の既出記事でも使われている語彙で意図的表現の可能性 |
| 5-1 | L113-L115 | grep 走査範囲 `scripts/` → `.`（ルート全走査） | 対象スキルは `scripts/` 配下のみの構成が明示（L34-L38）。`.` 全走査は `.git`/`node_modules` 等のノイズ増加リスクもあるためトレードオフ。著者判断 |
| 5-3 | L109-L118 | 検出ゼロ時の「対応策 C へ進む」導線追加 | 追記提案。既に対応策 C は後続章で十分詳述されており、導線は現行でも追える |
| 6 | L29 付近 | スキル素性（AI 生成である証拠 / ローカル個人作か第三者公開か）の 1 行補足 | 追記提案。記事の信頼性補強には有用だが、内容の良し悪しは著者判断。「見つけた」表現の意図に依存 |
| 7 | L40 | 「壮大」4 機能を平文→箇条書き、後続の動詞トレースと伏線回収 | ナラティブ強化（Low 優先）。現行で記事は成立。構成変更 |
| 8-b | L72-L74 | 仮説 3 を 1 文 → 2-3 文に肉付けし対称性を取る | 追記提案（Low 優先）。記述分量のバランスは著者判断 |

### 却下（0 件）
該当なし。すべての指摘は内容として妥当で、事実誤認や読み違いは見当たらないため、未採用分は保留（著者判断領域）に分類。

## High 指摘 2 件の扱い
- **指摘 5（grep パターン可読性）**: 3 つの下位論点のうち、`--print` 取りこぼしという客観的な技術欠陥のみ採用（**5-2**）。走査範囲変更（5-1）とフォローアップ導線（5-3）は運用判断のため保留。
- **指摘 6（対象スキル素性補足）**: 著者の意図（「見つけました」という語り口）との整合や、個人作/第三者公開の実態は著者のみが確定できるため保留。反映するなら著者による出典記述が必要。

## 検証
- [ ] 採用分 3 箇所の差分目視（表記揺れ / grep `--print` / カタカナ置換）
- [ ] 保留 5 件の判断が妥当か（特に指摘 6 のスキル素性補足は反映するか著者判断）
- [ ] `published: true` なので公開済み内容と整合しているか（文意変化なし）

## 実行ログ（並列セッション耐性）
- 作業開始時: `git branch --show-current` → `main`
- Edit 実行前: branch 確認 OK
- Commit 直前: `git branch --show-current` → `chore/apply-review-ai-generated-skill-md-reality-check-r2`（期待一致）
- 備考: 途中で並列セッションによる一時的なブランチ干渉の兆候を観測したが、再確認の結果 `main` に戻っていたため、新規ブランチ（`-r2` サフィックス）で再実行して完了

Closes #91（該当指摘の反映分）