### PR TITLE
docs(articles): dual-agent-repo-codex-and-claude-code のレビュー反映（採用 3 / 保留 7 / 却下 0）

### DIFF
--- a/articles/dual-agent-repo-codex-and-claude-code.md
+++ b/articles/dual-agent-repo-codex-and-claude-code.md
@@ -54,12 +54,12 @@ repo/
 │   ├── skills/               # Claude Code のスキル
 │   ├── agents/               # サブエージェント定義
 │   └── commands/             # Slash Commands
-├── .agents/                  # Codex 用（drift 管理は後述）
-│   └── skills/
+├── .agents/                  # AGENTS.md 標準のエージェント用（Codex など、drift 管理は後述）
+│   └── skills/               # 現状は .claude/skills と drift 管理中
 └── articles/
 ```
 
-`AGENTS.md` の冒頭で「Codex や Claude Code など AI エージェントはまずこのファイルを読む」と明示しておくと、新しいエージェントを導入したときも、既存の規約が自動で引き継がれます。
+`AGENTS.md` の冒頭で「Codex や Claude Code など AI エージェントはまずこのファイルを読む」と明示しておくと、AGENTS.md 標準に準拠する新しいエージェントを導入したときも、追加設定なしで同じ規約を読ませられます。
 
 ## drift（同期ズレ）管理の罠
 
@@ -79,7 +79,7 @@ repo/
    - メリット: シンプル
    - デメリット: Codex 固有のスキルを置きたい場合に困る
 
-今は 3 の方針を検討中です。`AGENTS.md` に全規約を寄せて、各エージェントの固有配下はツール索引に特化する、という整理。
+今は 3 の方針を検討中です。`AGENTS.md` に全規約を寄せて、各エージェントの固有配下はツール索引に特化する、という整理に向かっています。
 
 ## どちらで何を管理するか
 


### PR DESCRIPTION
## Summary
`reviews/zenn/dual-agent-repo-codex-and-claude-code.md` の指摘（High 0 / Medium 4 / Low 6）を `articles/dual-agent-repo-codex-and-claude-code.md` に選別反映します。

> ⚠️ **公開済み記事** (`published: true`)
> 本 PR は既に Zenn 上で公開されている記事への修正を含みます。マージ時に変更が反映されるため、文意が変わらないか最終レビューをお願いします。

## 採否一覧

### ✅ 採用 (3 件)
| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 6 | L82 | 体言止め「〜整理。」→ 敬体「〜整理に向かっています」 | 本文全体の敬体統一と明白に矛盾する表記揺れ |
| 7 | L62 | 「自動で引き継がれます」→「AGENTS.md 標準に準拠する新しいエージェント〜追加設定なしで同じ規約を読ませられます」 | 「自動で」は仕組みの実態（エージェント側が AGENTS.md を読む仕様に依存）を曖昧にする技術正確性の問題 |
| 8 | L57 | tree コメント「Codex 用（drift 管理は後述）」→「AGENTS.md 標準のエージェント用（Codex など、drift 管理は後述）」+ `skills/` 行に「現状は .claude/skills と drift 管理中」 | 読者が `.agents/` の位置づけを tree から追えるようにする明確化（事実誤認なし） |

### ⏸ 保留 (7 件)
| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1 | L28 | 「規約レイヤリング」の初出定義を「2 層規約」表現に寄せる or カッコ書き定義追加 | 核キーワードの表現統一はトーン判断を伴うため著者判断領域 |
| 2 | L70-L82 | drift 対応策に「4. CI で diff チェック」を追加し「4+3 採用」を明示 | 選択肢の再構成 + 運用方針の明示は追記提案の範囲、著者判断 |
| 3 | L133-L152 | 「Codex / Claude Code の得意不得意」セクションを役割分担表に書き換え or 別記事へ切り出し | 構成変更（節の大幅書き換え / 別記事化）は編集判断領域 |
| 4 | L30-L44 | 「規約とツールを分離」フレーズを表の前に先出し | 要点先出しの表現は複数の妥当解があり著者判断 |
| 5 | L109-L121 | 見出し「引っかかった罠」→「分離後に起きる運用の罠」 | 見出しの語感調整はトーン判断 |
| 9 | L162 | まとめ最終文にタイトル呼応の「2 層規約」再掲 | 締めの書き換えはトーン判断 |
| 10 | L5 | `topics` に「マルチエージェント」追加（「リポジトリ設計」と入れ替え） | SEO 判断・観測データに依存するため著者判断 |

### ❌ 却下 (0 件)
なし。

## 検証
- [ ] 採用分の差分目視（L57 tree コメント / L62 自動→追加設定なし / L82 体言止め→敬体）
- [ ] 保留 7 件の判断が妥当か（特に指摘 2, 3 は次回アップデート時の反映候補）
- [ ] `published: true` の公開済み内容との整合（文意変更なし、表現の明確化と統一のみ）

## 実行ログ
- 作業開始時ブランチ: `main`（期待通り）
- 作業ブランチ: `chore/apply-review-dual-agent-repo-codex-and-claude-code`（新規作成）
- 途中、commit が一度 `main` に着地する並列セッション干渉が発生したため、`git branch -f` で目的ブランチへ移動し `git reset --hard origin/main` で main を復旧（reflog で履歴追跡可能）

Closes related: `reviews/zenn/dual-agent-repo-codex-and-claude-code.md`