### PR TITLE
docs(articles): ai-generated-skill-md-reality-check の High 指摘 5 追補（grep 走査範囲拡張）

### DIFF
--- a/articles/ai-generated-skill-md-reality-check.md
+++ b/articles/ai-generated-skill-md-reality-check.md
@@ -110,9 +110,10 @@ ls engineer_profiles/some_user/
 
 ```bash
 # LLM 呼び出しの痕跡を幅広く探す（Claude CLI / Anthropic SDK / OpenAI SDK / Gemini）
-grep -rEi \
+# スキルのルート直下すべてを走査する（SKILL.md 内の埋め込みスクリプトも拾う）
+grep -rEi --exclude-dir=.git --exclude-dir=node_modules \
   "claude +(-p|--print)|curl.*(anthropic|openai|generativelanguage)|anthropic-ai/sdk|import +Anthropic|from +anthropic|import +openai|from +openai|google-generativeai" \
-  scripts/
+  .
 ```
 
 ## ズレが見つかったときの 3 つの対応策


### PR DESCRIPTION
## Summary

`reviews/zenn/ai-generated-skill-md-reality-check.md` の High 指摘 5（保留分）を追補反映します。先行 PR #94 で 3 件採用済みのレビューに対し、保留とした「grep 走査範囲の拡張」を副作用緩和のうえ採用します。

> ⚠️ **公開済み記事** (`published: true`)
> 本 PR は既に Zenn 上で公開されている記事への修正を含みます。マージ時に変更が反映されるため、文意が変わらないか最終レビューをお願いします。

## 採否一覧

### ✅ 追補採用 (1件)

| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 1 | L111-L116 | grep 走査範囲を `scripts/` → `.` に拡張 | SKILL.md 内の埋め込みスクリプトも拾えるようになり、セルフチェックの取りこぼしを削減 |

### 副作用緩和

保留時に懸念していた `.git` / `node_modules` のノイズは、`--exclude-dir=.git --exclude-dir=node_modules` を添えることで除外。典型的な Claude Code スキルのリポジトリ構成でも実用的に動作する形にした。

- `--exclude-dir` は GNU grep / BSD grep（macOS 標準）双方でサポート
- 既存の `-rEi` オプション、パターン文字列、言語選択（bash）は非変更
- Front Matter 非改変（`published: true` 維持）

### 修正前後 diff 抜粋

```diff
 # LLM 呼び出しの痕跡を幅広く探す（Claude CLI / Anthropic SDK / OpenAI SDK / Gemini）
-grep -rEi \
+# スキルのルート直下すべてを走査する（SKILL.md 内の埋め込みスクリプトも拾う）
+grep -rEi --exclude-dir=.git --exclude-dir=node_modules \
   "claude +(-p|--print)|curl.*(anthropic|openai|generativelanguage)|anthropic-ai/sdk|import +Anthropic|from +anthropic|import +openai|from +openai|google-generativeai" \
-  scripts/
+  .
```

## 関連

- 先行 PR: #94（採用 3 件マージ済み）
- レビュー: `reviews/zenn/ai-generated-skill-md-reality-check.md` 指摘 5

## 検証

- [ ] 採用分の差分目視（L111-L116 周辺）
- [ ] `--exclude-dir` で走査範囲が広がっても CI / プレビューに影響しない（記事本文のみ変更のため影響なし想定）
- [ ] `published: true` の公開済み内容と文意の整合

## 作業ログ

- 作業開始時 `git branch --show-current` → `main`
- ブランチ作成後 → `chore/apply-review-ai-generated-skill-md-high5-r2`
- commit 前確認 → `chore/apply-review-ai-generated-skill-md-high5-r2`
- push upstream 一致確認 → local/remote head 一致 (`a7ae871`)