### PR TITLE
[draft] docs(articles): align plangate review template outline

### DIFF
--- a/articles/plangate-ai-coding-workflow.md
+++ b/articles/plangate-ai-coding-workflow.md
@@ -52,7 +52,7 @@ PlanGateを一文で言うと、こうです。
 ## この記事で扱うもの
 
 - `PBI INPUT PACKAGE` の最小テンプレート
-- `plan.md / todo.md / test-cases.md / status.md` のひな形
+- `plan.md / todo.md / test-cases.md / review-self.md / review-external.md / status.md` のひな形
 - 3コマンド運用の使い方
 - レビュー時に見るチェックリスト
 


### PR DESCRIPTION
Issue #43 の保留項目のうち、`plangate-ai-coding-workflow` のテンプレート一覧と本文後段の構成を揃える小さな修正です。

変更内容:
- 3コマンド運用の前提として、`review-self.md` と `review-external.md` を一覧へ明示

検証:
- `git diff --check`
- `npm run check`
