### PR TITLE
[draft] docs(articles): include status in plangate plan checklist

### DIFF
--- a/articles/plangate-ai-coding-workflow.md
+++ b/articles/plangate-ai-coding-workflow.md
@@ -199,7 +199,7 @@ Zenn向けには、まずこの最小版で十分です。
 ## 3コマンド運用
 
 実際の操作はこの3つに絞ると運用しやすいです。
-`plan` の中で `plan.md / todo.md / test-cases.md / review-self.md` まで作り、人間レビューの前に `review-external.md` を追加してから `exec` に進みます。
+`plan` の中で `plan.md / todo.md / test-cases.md / review-self.md / status.md` まで作り、人間レビューの前に `review-external.md` を追加してから `exec` に進みます。
 
 ```text
 # 1. 作業コンテキスト作成


### PR DESCRIPTION
Issue #43 の保留項目のうち、`plangate-ai-coding-workflow` の本文内チェックリストの整合を 1 箇所だけ直します。

変更内容:
- `plan` で作る一覧に `status.md` を追加し、本文後段の説明と揃える

検証:
- `git diff --check`
- `npm run check`
