### PR TITLE
[draft] docs(articles): trim obsidian reference link label

### DIFF
--- a/articles/obsidian-supermemory-mcp.md
+++ b/articles/obsidian-supermemory-mcp.md
@@ -135,7 +135,7 @@ supermemory に保存した設計ノートを呼び出して
 - [Supermemory MCP 公式](https://mcp.supermemory.ai/)
 - [Cipher GitHub](https://github.com/byterover/cipher)
 - [Serena 解説記事](https://zenn.dev/aki_think/articles/c4f5b2a75ff4d4)
-- [Serena vs Cipher 比較記事 ](https://zenn.dev/minewo/articles/serena-vs-cipher-comparison)
+- [Serena vs Cipher 比較記事](https://zenn.dev/minewo/articles/serena-vs-cipher-comparison)
 - [Obsidian](https://obsidian.md/)
 
 ## 自社メディア


### PR DESCRIPTION
Issue #43 の保留候補として再確認した `obsidian-supermemory-mcp` の参考リンク表記を 1 箇所だけ整えます。

変更内容:
- `Serena vs Cipher 比較記事` のリンクラベル末尾スペースを削除

検証:
- `git diff --check`
- `npm run check`
