### PR TITLE
chore(articles): apply review feedback to ai-dev-guardrail-plangate-river-reviewer

### DIFF
--- a/articles/ai-dev-guardrail-plangate-river-reviewer.md
+++ b/articles/ai-dev-guardrail-plangate-river-reviewer.md
@@ -6,9 +6,7 @@ topics: ["AI駆動開発", "githubactions", "codereview", "claudecode", "automat
 published: false
 ---
 
-:::message
-この記事は、私が運営している [Growth Lab](https://the3396.com/articles) の検証ログと、[PlanGate](https://github.com/s977043/plangate/) / [River Reviewer](https://github.com/s977043/river-reviewer/) の公開リポジトリをもとに、AI駆動開発を実務で回すための設計を整理したものです。
-:::
+> 本記事は、[Growth Lab](https://the3396.com/articles) の検証ログと、[PlanGate](https://github.com/s977043/plangate/) / [River Reviewer](https://github.com/s977043/river-reviewer/) の公開リポジトリをもとに、AI 駆動開発を実務で回すための設計を整理したものです。
 
 :::message
 **この記事で得られること**


### PR DESCRIPTION
## Summary

`reviews/zenn/ai-dev-guardrail-plangate-river-reviewer.md` の指摘を `articles/ai-dev-guardrail-plangate-river-reviewer.md` に反映します。

（`published: false` のため ⚠️ バナーなし）

## 採否一覧

### 採用 (1件)

| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 1 | L9-L11 | 冒頭1ブロック目の `:::message`（出典）を `>` blockquote に変換 | 記法変更のみで本文削除なし。冒頭の同色 message box 連続2個による視覚的優先度の混在を解消（指摘10） |

### 保留 (4件)

| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1 | — | 指摘4: TL;DR表「強み」欄の情報粒度統一 | 表現の好み / 著者判断領域。現行の「ゲート設計」vs「再現性と学習可能性」も許容範囲 |
| 2 | — | 指摘7: mermaid図ラベルを日英併記に変更 | 日英表記の好み / 著者判断領域。日英一貫性は記事全体のトーンに関わる |
| 3 | — | 指摘8: 「小さく始める」節と「どちらを先に」節の統合 | 構成変更 / 著者判断領域。最新版では両節に内容が追加され充実化されており意図的な分割と判断 |
| 4 | — | 指摘9: TL;DR表「出力」欄で成果物と工程の混在 | 表現の好み / 著者判断領域 |

### 却下 (5件)

| # | 該当箇所 | 内容 | 却下理由 |
|---|---|---|---|
| 1 | — | 指摘1: L140「つまり、実装の前後でガードを分けるわけです。」削除 | mainへのpull後の最新記事で確認したところ既に削除済み / 対応済み |
| 2 | — | 指摘2: 個別紹介2節の圧縮と独自パートへの文量シフト | 最新記事では「Planで見たい項目」「Skillに落とすときの粒度」等が追加され著者が意図的に逆方向で充実化 |
| 3 | — | 指摘3: 「自社メディアでの位置づけ」節の削除または差し替え | 最新記事では節内に「どの時点で人間が承認するか」等4つの問いが追加され宣伝色が薄まっており著者が別の方法で対応済み |
| 4 | — | 指摘5: 節3「失敗した後」への情報追加 | 最新記事では失敗ログのコードブロックと具体的な説明が追加されており対応済み |
| 5 | — | 指摘6: 「実務で効く使い分け」節の導入文改善 | 最新記事のL243で「実務では、PlanGate で決めた基準を River Reviewer で確認し…という3つの局面で分けると扱いやすくなります。」と要点先出しが追加されており対応済み |

## 作業ログ（並列セッション耐性）

```
ブランチ確認開始時: chore/apply-review-note-n5a41a48f6d46 (並列セッション干渉を検知)
→ main に切り替え後 git pull --ff-only (11 commits fast-forward)
→ git switch -c chore/apply-review-ai-dev-guardrail-plangate-river-reviewer
最終確認: chore/apply-review-ai-dev-guardrail-plangate-river-reviewer
対象ファイル: 存在確認済み
```

## 検証

- [x] 採用分の差分目視（`:::message` → `>` の記法変換のみ、本文削除なし）
- [x] 保留/却下の判断が妥当か（最新記事との照合済み）
- [x] `published: false` のため公開済み内容との整合チェックは不要