### PR TITLE
docs(articles_note): apply review feedback to n5a41a48f6d46

### DIFF
--- a/articles_note/drafts/n5a41a48f6d46.md
+++ b/articles_note/drafts/n5a41a48f6d46.md
@@ -5,7 +5,7 @@
 > 更新: Thu, 02 Apr 2026 21:50:25 +0900
 > 区分: 個人
 
-こんにちは、みね@mine\_takeです。
+こんにちは、みね@mine_takeです。
 普段はベンチャー企業でEMとして働きつつ、個人開発や日々の実務の中で、AIをどう開発フローに組み込むかを試行錯誤しています。
 
 最近は、AIコーディングやAIレビューの実験を続ける中で、ひとつ強く感じていることがあります。
@@ -127,7 +127,7 @@ AIに倫理や自制を期待するのではなく、フローそのもので制
 PlanGateでは、ざっくり次の順で進めます。
 
 - 人間が PBI INPUT PACKAGE を書く
-- AI が plan / todo / test-cases を作る
+- AI が plan・todo・test-cases を作る
 - AI がセルフレビューする
 - 別の AI が独立レビューする
 - 人間が承認する
@@ -162,7 +162,7 @@ PlanGateの実装や背景は、GitHubでも公開しています。
 実際のテンプレートや運用手順は、Zennにまとめています。
 
 - PBI INPUT PACKAGE の最小テンプレート
-- [plan.md](http://plan.md) / [todo.md](http://todo.md) / [test-cases.md](http://test-cases.md) / [status.md](http://status.md) のひな形
+- `plan.md` / `todo.md` / `test-cases.md` / `status.md` のひな形
 - 3コマンド運用
 - レビュー時のチェックリスト
 


### PR DESCRIPTION
## Summary

`reviews/note/drafts/n5a41a48f6d46.md` の指摘を `articles_note/drafts/n5a41a48f6d46.md` に反映します。

> **note 下書き記事** (`state: drafts`)
> 本PRは note 上の下書き状態の記事への修正を含みます。マージ後は note 管理画面で手動確認・反映をお願いします。

## 採否一覧

### ✅ 採用 (3件)

| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 1 | L165 | `[plan.md](http://plan.md)` 等の実在しないURLリンクをコードスパン（バッククォート）に変換 | 壊れたリンクの修正。客観的な誤り（読者が到達不能なURLへ遷移するリスク） |
| 2 | L8 | `mine\_take` のバックスラッシュエスケープ残留を除去 → `mine_take` | Markdownエスケープ残留の修正。レンダラによって `\_` がそのまま表示されるリスク |
| 3 | L130 | 日本語文中の `plan / todo / test-cases`（半角スラッシュ区切り）を `plan・todo・test-cases`（中黒）に変換 | JTFスタイル準拠。日本語文中の並列は中黒を使う規約に基づく客観的な修正 |

### ⏸ 保留 (7件)

| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1 | L11-15 | 中核語「AI駆動開発」「AIコーディング」「AIレビュー」の関係を1文で整理し、敬体を統一する | 追記提案・語調調整。文面の生成を伴い著者判断領域 |
| 2 | L19-23 | 箇条書きの各行に主語（AI/人間）を明示 | 構成変更・トーン変更。意図的な文体の可能性があり著者判断 |
| 3 | L50-51 | 長文段落を箇条書きに切り出してスマホ可読性を向上 | 構成変更。著者判断領域 |
| 4 | L159-170 | Zenn誘導章の見出し変更と読後アクション段落の追加 | 構成変更・追記提案。著者判断領域 |
| 5 | L139-140 | GitHub アカウント差異（`s977043` vs `@mine_take`）への注記追加 | 追記提案。著者判断領域 |
| 6 | L183-185 | 締めへの読者問いかけCTA段落を追加 | 追記提案（新規文面生成を伴う）。著者判断領域 |
| 7 | 全体 | bold強調を2箇所程度に絞り込む（L28, L81, L93, L109 等を解除） | 編集判断・トーン調整。著者が意図した強調の可能性あり |

### ❌ 却下 (0件)

なし

## 実行ログ（並列セッション耐性確認）

```
$ git branch --show-current
chore/apply-review-note-n5a41a48f6d46  ✓

$ ls -1 articles_note/drafts/n5a41a48f6d46.md reviews/note/drafts/n5a41a48f6d46.md
articles_note/drafts/n5a41a48f6d46.md  ✓
reviews/note/drafts/n5a41a48f6d46.md   ✓
```

作業開始時のブランチが `chore/apply-review-note-ncced36189e87`（別タスクのブランチ）だったため、`git switch` で正しいブランチに移動してから Edit を実施しました。

## 検証

- [x] 採用分の差分目視（3件とも最小差分での修正を確認）
- [x] 保留/却下の判断が妥当か
- [ ] note 管理画面でプレビューし、リンクカード展開・コードスパン表示を確認