### PR TITLE
chore(articles): apply review to ai-code-review-feedback-ops

### DIFF
--- a/articles/ai-code-review-feedback-ops.md
+++ b/articles/ai-code-review-feedback-ops.md
@@ -160,30 +160,37 @@ AIに一般論だけを渡すと、レビューはどうしても一般論に寄
 
 レビュー本文の前に、まず PR のコンフリクト有無と CI の失敗状況を確認させます。
 
-- `gh pr view --json mergeable,mergeStateStatus` でコンフリクト確認
-- `gh pr checks` で CI 状態を確認
+```bash
+# コンフリクト確認（mergeable: CONFLICTING なら人間が対処してからレビュー）
+gh pr view --json mergeable,mergeStateStatus
+
+# CI 状態確認（failed があればコードレビュー前に対処）
+gh pr checks
+```
 
 これを最初にやるだけで、「コード以前に止まっている問題」と「コードレビューで見る問題」が混ざりにくくなります。
 
-### 変更内容に応じて review focus を切り替える
+### 変更内容に応じて review_focus（重点観点）を切り替える
 
-変更コンテキストから `review_focus` を渡して、重点観点を切り替えます。
+変更コンテキストから `review_focus`（「この変更で特に見るべき観点」を prompt に渡すパラメータ）を切り替えます。
 
-- migration を含むなら後方互換性を見る
-- API変更を含むならスキーマ互換性を見る
-- shared-components 変更を含むなら cross-site impact を見る
-- 認証変更なら auth / security を見る
-- フロント変更なら stale state / hydration / responsive を見る
+| 変更種別 | review_focus の重点観点 |
+| -------- | ----------------------- |
+| migration を含む | 後方互換性 |
+| API変更を含む | スキーマ互換性 |
+| shared-components 変更 | cross-site impact |
+| 認証変更 | auth / security |
+| フロント変更 | stale state / hydration / responsive |
 
 毎回同じ総花的レビューをさせるのではなく、**変更の種類に応じて注視点を増やす** ほうがノイズが減ります。
 
 ### レビューを三相に分ける
 
-自分たちの prompt では、レビューを `Upstream / Midstream / Downstream` の3段階に分けています。
+自分たちの prompt では、レビューを `Upstream / Midstream / Downstream`（設計・実装・テストの上流から下流）の3フェーズに分けています。
 
-- `Upstream`: 設計と依存方向
-- `Midstream`: 実装、バグ、性能、セキュリティ
-- `Downstream`: テストの有無と品質
+- `Upstream`（上流）: 設計と依存方向
+- `Midstream`（中流）: 実装、バグ、性能、セキュリティ
+- `Downstream`（下流）: テストの有無と品質
 
 こうしておくと、AIの指摘が命名や軽いスタイルに寄りすぎず、「設計」「実装」「テスト」のどこで問題が起きているかを整理しやすくなります。
 


### PR DESCRIPTION
## Summary

`reviews/zenn/ai-code-review-feedback-ops.md` の指摘を `articles/ai-code-review-feedback-ops.md` に反映します。

## 採否一覧

### 採用 (3件)

| # | 該当箇所 | 内容 | 反映理由 |
|---|---|---|---|
| 1 | L163-L164 (指摘5) | コマンド断片をコードブロックに整形し、返却値の判定コメントを添付 | コードの形式修正 / 再現性向上。インラインコードをコードブロックへ変換は客観的な修正 |
| 2 | L168-L177 (指摘3) | `review focus` 見出しを `review_focus（重点観点）` に変更し、箇条書き5項目を table に変換 | 英語ラベルへの日本語副題追加 + 並列・対称5項目の table 化 |
| 3 | L182-L187 (指摘4) | `Upstream / Midstream / Downstream` に `（設計・実装・テストの上流から下流）` 副題、各項目に `（上流）/（中流）/（下流）` を追加 | 英語ラベルの日本語副題追加（採用基準に合致） |

### 保留 (4件)

| # | 該当箇所 | 内容 | 保留理由 |
|---|---|---|---|
| 1 | L9-L15 (指摘1) | `:::message` を「想定読者・前提条件」に書き換え、TL;DR に結論を集約する | 新規文面の生成を伴う書き換え / 著者判断領域 |
| 2 | L157 後 (指摘2) | 第5章冒頭に5ステップの番号付き一覧を追加する | 新規文面の追加 / 著者判断領域 |
| 3 | L208-L212 (指摘6) | `minor/info` の件数目安（5件以内）追加と出口判定 table 追加 | 件数の具体値は著者判断。表の新規追加も文面生成を伴う |
| 4 | L275-L283 (指摘7) | まとめを「今週/来週以降/余裕が出たら」の行動ベースに書き換える | まとめの構成変更・追記提案 / 著者判断領域 |

### 却下 (0件)

なし

### SEO提案 (保留)

| # | 内容 | 保留理由 |
|---|---|---|
| 1 | topics に `githubactions` 追加・第5章見出し変更・h2 見出しにキーワード追加 | SEO改善提案 / タイトル・メタ情報変更は著者判断領域 |

## 検証

- [x] 採用分の差分目視（コードブロック整形・table 変換・日本語副題追加のみ、文意変更なし）
- [x] 保留/却下の判断が妥当か（新規文面生成・構成変更・著者判断領域は保留）
- [x] `published: false` のため公開済みバナー不要

## 実行ログ

```
git branch --show-current  => chore/apply-review-ai-code-review-feedback-ops
ls articles/ai-code-review-feedback-ops.md reviews/zenn/ai-code-review-feedback-ops.md => 両ファイル実在確認
```