### PR TITLE
feat(note-export-import): md_to_wxr.py で複数ソースを1本のWXRに束ねる対応

### DIFF
--- a/.claude/skills/note-export-import/scripts/md_to_wxr.py
+++ b/.claude/skills/note-export-import/scripts/md_to_wxr.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Markdown(単一記事) → note インポート用WXR XML を生成する。
+"""Markdown(単一/複数記事) → note インポート用WXR XML を生成する。
 
 使い方:
     python3 md_to_wxr.py articles_note/new/<slug>.md [--out articles_note/build/<slug>.xml]
-    python3 md_to_wxr.py articles_note/new/                # ディレクトリを指定すると全MDを一括変換
+    python3 md_to_wxr.py articles_note/new/                # ディレクトリ指定で全MDを1本のWXRに束ねる
+    python3 md_to_wxr.py articles_note/new/ articles_note/drafts/n2ef833cbece8.md  # 複数ソースをまとめて1本に
     python3 md_to_wxr.py ... --base-url https://raw.githubusercontent.com/OWNER/REPO/main/articles_note/assets/
 
 処理内容:
@@ -282,22 +283,54 @@ WRAPPER_HEAD = (
 WRAPPER_TAIL = "</channel></rss>"
 
 
-def collect_inputs(src: Path) -> list[Path]:
-    if src.is_dir():
-        return sorted(src.glob("*.md"))
-    return [src]
+def collect_inputs(srcs: list[Path]) -> list[Path]:
+    """複数のソースパス（ファイル/ディレクトリ）から .md ファイルを収集して重複排除。"""
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for src in srcs:
+        if src.is_dir():
+            for p in sorted(src.glob("*.md")):
+                rp = p.resolve()
+                if rp not in seen:
+                    seen.add(rp)
+                    result.append(p)
+        else:
+            rp = src.resolve()
+            if rp not in seen:
+                seen.add(rp)
+                result.append(src)
+    return result
+
+
+def derive_default_outname(srcs: list[Path]) -> str:
+    """出力ファイル名のスラッグを推定する。
+
+    - 単一ファイル: そのファイル名（stem）
+    - 単一ディレクトリ: ディレクトリ名（例: new, drafts）
+    - 複数: "bundle"
+    """
+    if len(srcs) == 1:
+        s = srcs[0]
+        return s.stem if s.is_file() else (s.name.strip("/") or "batch")
+    return "bundle"
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("src", type=Path, help="MDファイルまたはディレクトリ")
+    ap.add_argument(
+        "src",
+        type=Path,
+        nargs="+",
+        help="MDファイルまたはディレクトリ（複数指定可、すべて1本のWXRに束ねて出力）",
+    )
     ap.add_argument("--out", type=Path, help="出力先WXR (省略時: articles_note/build/import-<slug>-YYYYMMDD-HHMM.xml)")
     ap.add_argument("--base-url", help="assets/ 参照を絶対URLに書き換える (例: https://raw.githubusercontent.com/OWNER/REPO/main/articles_note/assets)")
     args = ap.parse_args()
 
     inputs = collect_inputs(args.src)
     if not inputs:
-        raise SystemExit(f"No .md found under {args.src}")
+        srcs_str = ", ".join(str(s) for s in args.src)
+        raise SystemExit(f"No .md found under {srcs_str}")
 
     items = "".join(render_item(p, i + 1, args.base_url) for i, p in enumerate(inputs))
     pubdate = datetime.now(timezone(timedelta(hours=9))).strftime("%a, %d %b %Y %H:%M:%S +0900")
@@ -306,7 +339,7 @@ def main():
     if args.out:
         out = args.out
     else:
-        slug = args.src.stem if args.src.is_file() else args.src.name.strip("/") or "batch"
+        slug = derive_default_outname(args.src)
         ts = datetime.now(timezone(timedelta(hours=9))).strftime("%Y%m%d-%H%M")
         out = Path("articles_note/build") / f"import-{slug}-{ts}.xml"
     out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
ユーザー要望「インポート可能なファイルを個別ではなく、まとめて用意して欲しい」への対応。

`md_to_wxr.py` の `src` 引数を `nargs="+"` で複数指定可能にした。ファイル/ディレクトリを混在指定でき、まとめて1本の WXR に出力する。

## 変更点
- `src` を複数受け入れ（`nargs="+"`）
- ファイル・ディレクトリ混在 OK（ディレクトリは中の .md を収集）
- 重複排除（同じパスを複数渡しても1記事として扱う）
- 出力スラッグ自動推定: 単一→stem/ディレクトリ名、複数→`"bundle"`

## 使用例
```bash
# new/ 配下を1本のWXRに束ねる
python3 md_to_wxr.py articles_note/new/

# 複数ソースを混在指定
python3 md_to_wxr.py articles_note/new/ articles_note/drafts/n2ef833cbece8.md

# 出力名指定
python3 md_to_wxr.py articles_note/new/ --out articles_note/build/import-bundle-new.xml
```

## 検証
- `articles_note/new/` (5記事) → 5 items / verify PASS
- `articles_note/new/ + drafts/<6files>` (11記事) → 11 items / verify PASS

note インポートは1ファイル1リクエストだが、1ファイル内に複数 `<item>` を含められるため、**束ねるとアップロード回数が1回で済む**。

## Test plan
- [x] 既存動作（単一ファイル / 単一ディレクトリ）が壊れていない
- [x] 複数ソース指定で全 .md が WXR に含まれる
- [x] 重複指定で重複 item が出ない
- [x] verify_wxr.py 全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)