### PR TITLE
chore: __pycache__ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ articles_note/build/
 
 # Claude Code スケジュール実行の排他ロック (ランタイム生成)
 .claude/scheduled_tasks.lock
+
+# Python バイトコードキャッシュ (note-export-import スクリプト実行で生成)
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- note-export-import の Python スクリプト実行で生成される `__pycache__/` を gitignore 対象に追加
- `.claude/skills/note-export-import/scripts/__pycache__/` が `git status` を毎回汚していた状態を解消

## Test plan
- [x] `git status` に `__pycache__/` が出ないことを確認
- [x] `.pyc` も併せて除外