### PR TITLE
docs(zenn): publish Codex migration guide

### DIFF
--- a/articles/claude-code-to-codex-app-migration.md
+++ b/articles/claude-code-to-codex-app-migration.md
@@ -3,7 +3,7 @@ title: "Claude CodeからCodex Appへ移行する実践ガイド"
 emoji: "🛠️"
 type: "tech"
 topics: ["codex", "claudecode", "openai", "mcp", "ai駆動開発"]
-published: false
+published: true
 ---
 
 :::message


### PR DESCRIPTION
## Summary

- Zenn記事 `articles/claude-code-to-codex-app-migration.md` を公開対象に切り替えます
- 変更は front matter の `published: false` → `true` のみです
- PlanGate記事、Qiita、note の公開状態は変更しません

## Publishing scope

- Zenn: Codex移行ガイドのみ公開
- PlanGate Zenn: PlanGate側 README更新PR #190 が未mergeのため公開保留
- Qiita: `ignorePublish: true` 維持
- note: `articles_note/new/` 維持

## Test plan

- [x] `npm run check`
- [x] `git diff --check`
- [x] 公開フラグ差分が対象1記事のみであることを確認