### PR TITLE
docs(zenn): rewrite PlanGate article around v8.6.0 Metrics v1 / Governance

### DIFF
--- a/articles/plangate-v85-hook-enforcement.md
+++ b/articles/plangate-v85-hook-enforcement.md
@@ -1,5 +1,5 @@
 ---
-title: "AIコーディングを承認なしに走らせない：PlanGate v8.6.0のHarness Improvement入門"
+title: "AIコーディングを「比較で改善」できる土台にする：PlanGate v8.6.0のMetrics v1とGovernance"
 emoji: "🚦"
 type: "tech"
 topics: ["ai", "claudecode", "githubactions", "oss", "automation"]
@@ -20,328 +20,226 @@ PlanGate は、この問題に対して「AIをもっと賢くする」のでは
 
 > 承認なし、コードなし。
 
-この記事では、PlanGate v8.6.0 時点の考え方と、Hook enforcement に加えて Metrics v1 と Governance で何を見られるようになったのかを整理します。
+v8.5.0 で Hook enforcement 10/10 が完成し、「実行時に止める」仕組みは出揃いました。続く v8.6.0 では、その上に **Metrics v1 / Issue governance / Baseline** が乗りました。
+
+ひとことで言うと、**「止めた回数を集計して比較できる harness」** に進化しています。
+
+この記事では v8.6.0 で追加された 4 本柱（baseline・governance・privacy・Metrics v1）を、実際にどう使うかという視点で整理します。
 
 :::message
 この記事で得られること
 
-- AIコーディングで「実装前に止める」設計が必要になる理由
-- PlanGate の C-3 / C-4 gate と成果物の全体像
-- v8.6.0 の Hook enforcement と Metrics v1 が何を守り、何を観測するのか
-- 小さく導入するための順番と、最初に見るべきファイル
+- Hook enforcement だけでは足りなかった「観測」と「比較」の論点
+- Metrics v1 が記録する 11 events と、`plangate metrics` の使い方
+- Issue governance の「推測禁止条項」と Roadmap PBI テンプレート
+- Baseline を取って後続改善を比較で判断する流れ
+- v8.6.0 を導入する順序と、最初に読むファイル
 :::
 
 ## TL;DR
 
-PlanGate は、AI コーディングエージェントを安全に使うための軽量ガバナンスハーネスです。
+PlanGate は AI コーディングエージェントを安全に使うための軽量ガバナンスハーネスです。
 
-実装前に `plan.md` / `todo.md` / `test-cases.md` を作り、人間が C-3 gate で承認してから `exec` に進みます。
+- v8.5.0 までで **Hook enforcement 10/10**（承認前実装、計画改変、scope 外編集、merge 承認漏れなどを実行時に検査）が揃った
+- v8.6.0 では **Harness Improvement Roadmap Phase 0/1** として、改善前 baseline → governance → privacy → Metrics v1 を順に整備
+- 11 events の JSON Schema と CLI（`plangate metrics --collect/--report`）で、TASK 単位の運用イベントを後から集計できる
+- 改善前 baseline と Issue governance により、以後の harness 改善（Eval expansion / Model Profile v2 / Keep Rate / Dynamic Context）を **感覚ではなく比較で判断** できる
+- Tests は 24 → **32 PASS**（CLI 側）、Hook 側は 42 PASS を維持
 
-v8.6.0 では Hook enforcement 10/10 を土台に、Metrics v1、baseline、Issue governance が加わりました。承認前の実装、計画改変、検証 evidence 不足、scope 外編集などを検査しつつ、運用改善を数字とルールで追いやすくなっています。
-
-「AIに速く書かせる」だけでなく、「AIがどこで止まるべきか」をチームで定義したい場合に向いています。
+「AIに速く書かせる」だけでなく、「AIがどこで止まり、どれくらい止まっているか」をチームで観測したい場合に向いています。
 
 ## この記事の対象読者
 
 - Claude Code / Codex CLI などのAIコーディングエージェントを実務で使っている人
 - AIが作るPRの差分が大きくなり、レビューに困っている人
-- スクラムやPBIベースの開発で、AIにも計画・承認・検証の流れを守らせたい人
-- OSSとしてPlanGateを試す前に、思想と導入順を把握したい人
+- Hook で止めるところまでは入れたが、「効いているか」を数字で見られていない人
+- スクラムやPBIベースの開発で、AI運用の改善を retrospective で回したい人
 
-## 通常のAI実装依頼との違い
+## v8.5.0 と v8.6.0 の役割分担
 
-PlanGateは、AIに実装させること自体を否定するものではありません。
+PlanGate の進化は「止める」と「観測する」を分けて理解すると整理しやすいです。
 
-違いは、実装開始前に「判断可能な成果物」を固定することです。
-
-| 観点 | 通常のAI実装依頼 | PlanGate経由 |
+| バージョン | 主役 | 何が揃ったか |
 | --- | --- | --- |
-| 開始条件 | Issueや依頼文を読んだら実装開始 | `plan.md` / `todo.md` / `test-cases.md` 作成後、C-3承認で開始 |
-| スコープ制御 | プロンプト上の注意に依存 | Non-goals / allowed_files / forbidden_files で境界を明示 |
-| レビュー入口 | 生成された差分を読む | plan / test-cases / evidence と差分を照合する |
-| 失敗時の戻し方 | 実装差分を戻す | 計画段階で修正しやすい |
-| 監査性 | 会話ログに残りがち | `docs/working/TASK-XXXX/` に成果物として残す |
+| v8.4.0 | Hook 基盤 | default warning / strict block / bypass の 3 mode 設計 |
+| v8.5.0 | Hook enforcement 完成 | 10/10 hooks 実装、tests 21→42 PASS |
+| **v8.6.0** | **観測と比較** | **Metrics v1 / Issue governance / Privacy / Baseline** |
 
-AIが速く実装するほど、チーム側には「実装前に何を合意したか」が必要になります。
+v8.5.0 までは「危ない条件をどれだけ止められるか」が課題でした。v8.6.0 からは「**どこで何回止まったかを記録して、harness 自体を改善できるか**」がテーマです。
 
-PlanGateは、その合意をファイルとgateとして残すための仕組みです。
+## v8.6.0 で追加された 4 本柱
 
-## PlanGateとは
+EPIC #193 [Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) の v8.6.0 milestone P0 として、4 つの PBI が**この順序で**実装されました。
 
-PlanGate は、AI コーディングエージェントのためのガバナンス優先ワークフローハーネスです。
+| # | PBI | ドキュメント | 役割 |
+| --- | --- | --- | --- |
+| 1 | #194 Baseline alignment | `docs/ai/eval-baselines/2026-05-04-baseline.{md,json}` | 改善前の状態を固定 |
+| 2 | #201 Issue/Label/Milestone Governance | `docs/ai/issue-governance.md` | 推測禁止条項と Roadmap PBI テンプレ |
+| 3 | #202 Metrics Privacy | `docs/ai/metrics-privacy.md` | 保存可能 12 / 禁止 9 カテゴリ |
+| 4 | #195 Metrics v1 | `schemas/plangate-event.schema.json` ほか | 11 events と CLI 集計 |
 
-中心にある考え方はシンプルです。
+順序が大事です。governance（何を Issue として残すか）と privacy（何を記録してよいか）を先に決めてから Metrics v1 を実装することで、schema 設計時に privacy §3/§4 が先行参照され、**「Forbidden カテゴリは schema 上に存在させない」設計を強制**できます。
 
-```text
-PBIを書く
-→ AIが計画を作る
-→ 人間がC-3で承認する
-→ AIが実装する
-→ 検証する
-→ PRでC-4レビューする
-→ マージする
+## Metrics v1：11 events で運用を記録する
+
+Metrics v1 のスキーマ（`schemas/plangate-event.schema.json`）が記録する events は次の 11 種類です。
+
+| Event | 何を記録するか |
+| --- | --- |
+| `task_initialized` | TASK ディレクトリ作成、PBI 番号、mode |
+| `plan_generated` | plan.md / todo.md / test-cases.md 揃ったか |
+| `c3_decided` | C-3 承認結果（APPROVED / CONDITIONAL / REJECTED） |
+| `exec_started` | exec フェーズ開始 |
+| `hook_violation` | どの hook が、どの条件で発火したか |
+| `v1_completed` | V-1 検証完了、AC PASS/FAIL/WARN 件数 |
+| `fix_loop_incremented` | 修正ループの回数 |
+| `external_review_completed` | V-3 外部レビュー結果 |
+| `pr_created` | PR 番号と差分サマリ |
+| `c4_decided` | C-4 マージ承認 |
+| `handoff_completed` | handoff の必須要素チェック |
+
+各 event は **conditional required**（c3 / c4 / v1 / hook / fix_loop それぞれに必須フィールドあり）として定義されており、形式違反は schema 検証で弾かれます。
+
+### CLI で集計する
+
+スキーマと並んで、`scripts/metrics_collector.py` / `scripts/metrics_reporter.py` が用意されています。`bin/plangate metrics` 経由で呼び出します。
+
+```bash
+# TASK ディレクトリから 6 events を自動導出して NDJSON に追記
+bin/plangate metrics --collect TASK-0061
+
+# events.ndjson から TASK 単位のサマリを表示
+bin/plangate metrics --report TASK-0061
+
+# 全 TASK 横断で集計（hook violation / C-3 / V-1 / C-4 / fix_loop_max / mode）
+bin/plangate metrics --aggregate
+
+# JSON 出力（dashboard / 後続ツール連携向け）
+bin/plangate metrics --aggregate --json
 ```
 
-つまり、AIにいきなり実装させるのではなく、先に次の成果物を作らせます。
+`--collect` は dry-run モード（`--dry-run`）も持っているので、最初は NDJSON に書かずに events 抽出結果だけ確認できます。
 
-- `plan.md`
-- `todo.md`
-- `test-cases.md`
-- `review-self.md`
-- `approvals/c3.json`
+### Privacy はスキーマで強制する
 
-実装に進む前に、人間が「この計画でよいか」を判断します。
+events.ndjson は `docs/working/_metrics/events.ndjson` に出力されますが、**`.gitignore` で除外されており public repo に commit されません**。これは `docs/ai/metrics-privacy.md` §8 の要件です。
 
-この時点で止められるのが重要です。実装後に方向修正するより、計画段階で止めるほうが安く済みます。
+`metrics-privacy.md` は次のように 12/9 カテゴリで線引きしています。
 
-## なぜHook enforcementが必要なのか
+- **保存可能 12 カテゴリ**: TASK ID、event 種別、timestamp、mode、AC count、hook 名、C-3/C-4 decision、V-1 result、fix loop count、PR 番号、差分行数集計、handoff 必須要素チェック結果
+- **禁止 9 カテゴリ**: file path（フルパス）、stack trace、command output、provider metadata、API key、ユーザー名、commit message 全文、コード本文、private prompt 内容
 
-プロンプトに「承認前に実装しないでください」と書くだけでも、ある程度は効きます。
+設計時にこの線引きが入っているので、Metrics v1 を on にしただけで漏れる、という事故が起きにくい構造になっています。
 
-しかし、実務で使うなら、それだけでは弱いです。
+## Issue governance：「推測禁止条項」とは
 
-LLMは文脈を誤解することがあります。長いセッションでは指示の優先度も揺れます。人間側も、急いでいると承認前に実装へ進ませてしまうことがあります。
+`docs/ai/issue-governance.md` で正本化された Issue 運用ルールの目玉が、§4 **推測禁止条項**です。
 
-そこで PlanGate v8.6.0 では、Hook enforcement を土台に、守りたい不変条件を Hook と CLI で検査し、さらに Metrics v1 と governance で改善状態を追える方向に寄せました。
+> Roadmap PBI を Issue 化するとき、Why / What / AC / Non-goals / Labels / Milestone を**推測で埋めてはならない**。明示されていない要素は「未確定」として残し、確定後に更新する。
 
-言い換えると、次の役割分担です。
+これは v8.5.0 → v8.6.0 期間で発覚した「11 PBI が誤って v7.x milestone に紐付いていた」という事故への再発防止策です。AI に Issue Form を埋めさせると、それっぽい milestone を**もっともらしく推測してくれてしまう**ため、ルールとして禁止しました。
 
-| 層 | 役割 |
-| --- | --- |
-| Prompt | 目的、成功条件、停止条件を伝える |
-| Artifact | plan / todo / test-cases / approval / evidence を残す |
-| CLI | 成果物と承認状態を検証する |
-| Hook | 破ってはいけない条件を実行時に検査する |
+支える仕組みは 2 つです。
 
-プロンプトでお願いするだけではなく、実行時のガードとして扱うのがポイントです。
+1. `.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml` — Roadmap PBI 用 Issue Form。Why / What / AC / Non-goals / Labels / Milestone を**必須入力として強制**
+2. `docs/ai/issue-governance.md` の Label taxonomy — kind / area / priority / status の **4 軸**で分類、milestone mapping は別ドキュメントで明示
 
-## v8.6.0で守り、観測できるようになったこと
+「AI が代わりに書ける部分」と「人間が確定するまで埋めてはいけない部分」を分離するのが要点です。
 
-v8.6.0 では、Hook enforcement 10/10 は維持したまま、Harness Improvement Roadmap の Phase 0/1 として baseline、Issue governance、Metrics v1 が追加されました。
+## Baseline：改善前を固定する
 
-代表的には、次のような検査ができます。
+`docs/ai/eval-baselines/2026-05-04-baseline.{md,json}` には、v8.5.0 直後時点の baseline が記録されています。
+
+- 代表 5 TASK（TASK-0050 / 0054 / 0055 / 0056 / 0057）を選定
+- 既存の 8 観点 eval（scope / approval / AC coverage / verification / stop / tool overuse / format / latency-cost）を全件適用
+- 機械可読な JSON snapshot を併置し、後続改善との diff が取れる形に
+
+これがあることで、たとえば v8.7.0 候補の **#196 Eval expansion** や **#197 Model Profile v2** を入れたときに、「観点ごとに何点改善したか」を baseline JSON との diff で示せます。
+
+逆に言うと、baseline がないままでは harness 改善を入れても「なんとなく良くなった気がする」で終わります。v8.6.0 はこの「気がする」を消しに行ったリリースです。
+
+## Hook enforcement の役割は変わらない
+
+v8.6.0 でも、v8.5.0 で完成した Hook enforcement 10/10 はそのまま土台として動きます。Metrics v1 はこれらの hook 発火を `hook_violation` event として記録するレイヤーであり、**hook を置き換えるものではありません**。
+
+念のため、現行 10 hooks の役割をまとめておきます。
 
 | Hook | 目的 |
 | --- | --- |
-| EH-1 | `plan.md` なしの production code 編集を検知する |
-| EH-2 | C-3承認なしの実装をブロックする |
-| EH-3 | 承認後の `plan.md` 改変を `plan_hash` で検知する |
-| EH-4 | `test-cases.md` なしの V-1 実行を検知する |
-| EH-5 | 検証 evidence なしの PR 作成を検知する |
-| EH-6 | `forbidden_files` による scope 外編集を検知する |
-| EH-7 | C-3 / C-4 承認なしのマージを検知する |
-| EHS-1 | standard 以上で V-3 外部レビューを必須化する |
-| EHS-2 | handoff の必須要素を検査する |
-| EHS-3 | fix loop の上限超過を検知する |
+| EH-1 | `plan.md` なしの production code 編集を検知 |
+| EH-2 | C-3 承認なしの実装をブロック |
+| EH-3 | 承認後の `plan.md` 改変を `plan_hash` で検知 |
+| EH-4 | `test-cases.md` なしの V-1 実行を検知 |
+| EH-5 | 検証 evidence なしの PR 作成を検知 |
+| EH-6 | `forbidden_files` による scope 外編集を検知 |
+| EH-7 | C-3 / C-4 承認なしのマージを検知 |
+| EHS-1 | standard 以上で V-3 外部レビューを必須化 |
+| EHS-2 | handoff の必須要素を検査 |
+| EHS-3 | fix loop の上限超過を検知 |
 
-テストスイートも分かれています。
+テストスイート構成も同じです。
 
 ```bash
-sh tests/run-tests.sh        # CLI / eval / schema など
+sh tests/run-tests.sh        # CLI / eval / schema / metrics
 sh tests/hooks/run-tests.sh  # hook enforcement
 ```
 
-v8.6.0 時点では、CLI側が 32 PASS、hook側が 42 PASS です。
+v8.6.0 時点では、**CLI 側 32 PASS（v8.5.0 の 24 から +8）、Hook 側 42 PASS**。+8 はすべて Metrics v1 用の `tests/extras/ta-09-metrics.sh`（schema validation / 各 event 検出 / aggregate report / JSON 出力）から来ています。
 
-加えて、`schemas/plangate-event.schema.json` と `scripts/metrics_collector.py` / `scripts/metrics_reporter.py` により、task initialized、plan generated、C-3 decision、hook violation、V-1 complete、PR created、C-4 decision などのイベントを後から集計できるようになりました。
+## v8.6.0 を試す順序
 
-ここで大事なのは、Hook が止めたかどうかだけを見るのではなく、「どのタスクで、どの境界を越えそうになったか」を改善材料として残せることです。
+PlanGate を新規導入する場合と、すでに v8.5.0 を運用している場合で順序が変わります。
 
-v8.6.0 では、改善前の baseline と Issue governance も整えています。以後の harness 改善を、感覚ではなく比較で判断するための土台です。
-
-## 最小導入の流れ
-
-PlanGateを試すだけなら、最初からすべてのHookを本番運用に入れる必要はありません。
-
-まずは、1つのタスクで次の流れを試すのが現実的です。
+### 新規導入の場合
 
 ```bash
-# 1. 作業コンテキスト作成
+# 1. 1 タスクで plan → approve → exec を試す
 /working-context TASK-0001
-
-# 2. plan / todo / test-cases を作る
 /ai-dev-workflow TASK-0001 plan
-
-# 3. 人間が plan.md を読む
-#    APPROVE / CONDITIONAL / REJECT を判断する
-
-# 4. 承認後に実装へ進む
+# 人間が plan.md を読み APPROVE
 /ai-dev-workflow TASK-0001 exec
 ```
 
-この時点で見るべきものは、完璧な自動化ではありません。
+ここまで触ってから Hook と Metrics に進むのが現実的です。最初から Metrics v1 を on にしても、observe する対象（TASK 履歴）が無いと意味がありません。
 
-大事なのは、AIがコードを書く前に、次の3点を人間が確認できるかです。
+### v8.5.0 から上げる場合
 
-- 何をやるか
-- 何をやらないか
-- どうなったら終わりか
+1. **Privacy を読む**: `docs/ai/metrics-privacy.md` の保存可能 12 / 禁止 9 を、自分のチームの公開ポリシーと突き合わせる
+2. **Baseline を取る**: 既存 TASK から代表 3〜5 件を選び、`docs/ai/eval-baselines/` に snapshot を作る
+3. **Metrics を dry-run で回す**: `bin/plangate metrics --collect <TASK> --dry-run` で events 抽出が想定通りか確認
+4. **Issue governance を適用**: 既存の Roadmap Issue を `plangate-roadmap-task.yml` テンプレートに合わせて整理。milestone は推測で埋めない
+5. **NDJSON 蓄積を開始**: dry-run を外し、`bin/plangate metrics --aggregate` で週次に集計
 
-この3点が揃わないまま実装に入ると、AIが速いほど差分も速く膨らみます。
+特に 1 と 2 を飛ばすと、「Metrics は取れているが何と比較すればいいか分からない」状態に陥ります。
 
-## plan.mdで見るべき項目
+## 次の EPIC：v8.7.0 / v8.8.0 / v8.9.0
 
-PlanGateでは、`plan.md` が単なる作業メモではなく、実装に進むための判断材料になります。
+CHANGELOG にある通り、v8.6.0 milestone P0 完走を受けて、次のロードマップが見えています。
 
-私は最低限、次の項目を見ます。
+- **v8.7.0 (P1)**: #196 Eval comparison for harness changes、#197 Model Profile v2、#203 Tool Error Taxonomy、#204 PlanGateBench Fixture Suite
+- **v8.8.0 (P1/P2)**: #198 Keep Rate v1（Code / Plan / Acceptance / Handoff）、#199 Dynamic Context Engine v1
+- **v8.9.0 (P2)**: #200 Reporting & Retrospective（sprint retrospective 統合）
 
-```markdown
-# Plan
-
-## Goal
-今回達成すること
-
-## Non-goals
-今回はやらないこと
-
-## Scope
-変更対象と影響範囲
-
-## Test plan
-実行するテスト、追加するテスト
-
-## Risks
-壊れやすい箇所、確認が必要な前提
-
-## Acceptance criteria
-完了条件
-```
-
-特に重要なのは `Non-goals` です。
-
-AIは親切なので、関連する改善をつい広げます。リファクタリング、命名整理、文言の調整、周辺コンポーネントの整理など、単体では良さそうな変更が混ざることがあります。
-
-しかし、レビュー可能性を保つには「今回はやらないこと」を先に決める必要があります。
-
-`Non-goals` があると、レビューで次のように判断できます。
-
-```text
-この変更自体は良さそうだが、今回のNon-goalsに含まれているため別PRに分ける。
-```
-
-これは、AIを縛るためというより、チームの判断を安定させるための線引きです。
-
-## forbidden_filesでスコープを守る
-
-v8.6.0でも引き続き実務向けなのが、`forbidden_files` による scope 外編集検知です。
-
-たとえば、子PBIで次のような境界を置けます。
-
-```yaml
-allowed_files:
-  - src/features/user-list/**
-  - tests/user-list/**
-
-forbidden_files:
-  - prisma/schema.prisma
-  - src/app/api/**
-  - .github/workflows/**
-```
-
-このような情報があると、AIが関連ファイルを広く読んだとしても、編集してよい範囲を明確にできます。
-
-AIにとって「関連がありそう」は、必ずしも「今回変更してよい」ではありません。
-
-この違いを明示できるのが、PlanGateの運用上の価値です。
-
-## evalとschemaで後から検証する
-
-PlanGateは、計画とHookだけではなく、evalとschemaも持っています。
-
-`bin/plangate eval` は、完了済みタスクから8観点の評価を生成します。
-
-例として、次のような観点を扱います。
-
-- scope discipline
-- approval discipline
-- acceptance criteria coverage
-- verification honesty
-- stop behavior
-- tool overuse
-- format adherence
-- latency / cost
-
-また、`validate-schemas` によって、JSON artifact が schema に合っているかも検証できます。
-
-```bash
-bin/plangate validate-schemas TASK-0001
-bin/plangate eval TASK-0001 --no-write
-```
-
-AI駆動開発では、実装速度だけを見ると判断を誤ります。
-
-スコープを守れたか、承認前に進まなかったか、検証結果を正直に残したか。こうした観点を後から見られることが、運用を安定させます。
-
-## 導入前チェックリスト
-
-PlanGateを入れる前に、まず次の問いに答えられるかを確認すると、導入しやすくなります。
-
-- AIが実装に入る前に、人間が承認すべき成果物は何か
-- 今回やらないことを、どこに書くか
-- テスト観点を、実装前に誰が確認するか
-- scope外ファイルをどう定義するか
-- 実装後の検証 evidence をどこに残すか
-- C-4のPRレビューで、人間が最終判断する観点は何か
-
-この問いに答えられない場合、いきなりHookをstrictにするより、まず `plan.md` と `test-cases.md` の運用から始めるほうがよいです。
-
-## どこから本番導入するか
-
-いきなり全Hookをstrictにする必要はありません。
-
-おすすめは、次の順番です。
-
-1. まず `plan.md` / `test-cases.md` / C-3承認を手動運用で試す
-2. 次に `bin/plangate validate` をCIやPR前チェックに入れる
-3. その後、誤検知が少ないHookからdefault warningで入れる
-4. 運用が固まったものだけ strict block に上げる
-
-PlanGateのHookには、default / strict / bypass の3モード設計があります。
-
-| モード | 使い方 |
-| --- | --- |
-| default | warning中心。導入初期向け |
-| strict | ブロックする。本番運用向け |
-| bypass | 緊急時のescape。監査ログ前提 |
-
-最初からすべてを止めると、AI作業の妨げになることがあります。
-
-まずはwarningで観測し、どの条件なら安全にブロックできるかを見るほうが現実的です。
+これらはすべて、v8.6.0 で固定した baseline と Metrics v1 イベントログの上で「比較可能」な形で評価される予定です。
 
 ## まとめ
 
-AIコーディングエージェントの課題は、「コードを書けるか」から「どう安全に進めるか」へ移っています。
+AIコーディングエージェントの課題は、「コードを書けるか」から「どう安全に進めるか」へ、そして「**改善できているか観測できるか**」へと移っています。
 
-PlanGateは、そのための軽量なガバナンスハーネスです。
+- v8.5.0 までで「止める」が出揃った（Hook enforcement 10/10）
+- v8.6.0 で「観測する・比較する」が出揃った（Metrics v1 / governance / baseline / privacy）
+- 次の v8.7.0 以降は、この土台の上で harness 自体の改善を**比較で判断**していくフェーズに入る
 
-- 計画を作る
-- 人間が承認する
-- 承認後に実装する
-- 検証結果を残す
-- Hook / CLI / Schema / Evalで運用を検査する
+PlanGate v8.6.0 は、AI 運用を retrospective に乗せるための土台が揃ったリリースです。Hook で止めた経験があるチームほど、「止めた回数の集計」と「baseline との比較」の効きが体感できると思います。
 
-この流れにすると、AIの速度を活かしながら、チームがレビューできる形を保ちやすくなります。
-
-AIに任せる範囲を広げるほど、止める場所の設計が重要になります。
-
-PlanGate v8.6.0 は、その「止める場所」をプロンプトのお願いではなく、実行可能な仕組みと改善可能なメトリクスに近づけるための一歩です。
-
-まず試すなら、1つのタスクだけで十分です。
-
-`plan.md` を作らせ、人間が読み、承認してから実装に進める。そこから始めるだけでも、AIとの開発はかなりレビューしやすくなります。
-
-## 次の一歩
-
-- まずは PlanGate の README を読み、`plan → approve → exec` の流れを確認する
-- 既存の小さなIssueを1つ選び、`plan.md` と `test-cases.md` だけを手動で試す
-- 良さそうなら GitHub でスターして、後で試せるように保存する
-- 実際に試して詰まった点があれば、Issue や Discussions でフィードバックする
-
-PlanGate はまだ発展中のOSSです。
-AIコーディングをチームで安全に回すためのハーネスとして、実務からのフィードバックを歓迎しています。
+まず 1 タスクから試すなら、新規導入の流れと同じです。Metrics v1 まで使いたい場合は、`docs/ai/metrics-privacy.md` を最初に読んでから `--dry-run` で 1 周してみてください。
 
 ## 参考リンク
 
 - [PlanGate GitHub Repository](https://github.com/s977043/PlanGate)
-- [CHANGELOG](https://github.com/s977043/PlanGate/blob/main/CHANGELOG.md)
+- [CHANGELOG（v8.6.0）](https://github.com/s977043/PlanGate/blob/main/CHANGELOG.md)
+- [Harness Improvement Roadmap (EPIC #193)](https://github.com/s977043/plangate/issues/193)
+- [Issue governance](https://github.com/s977043/PlanGate/blob/main/docs/ai/issue-governance.md)
+- [Metrics privacy](https://github.com/s977043/PlanGate/blob/main/docs/ai/metrics-privacy.md)
+- [Metrics 運用 guide](https://github.com/s977043/PlanGate/blob/main/docs/ai/metrics.md)
 - [Hook enforcement](https://github.com/s977043/PlanGate/blob/main/docs/ai/hook-enforcement.md)


### PR DESCRIPTION
## Summary
PlanGate 記事 (`articles/plangate-v85-hook-enforcement.md`) を v8.6.0 リリースに合わせて全面書き換え。

- 主役を v8.5.0 の Hook enforcement から v8.6.0 の「観測と比較」に再構成
- v8.6.0 で追加された 4 本柱（baseline / governance / privacy / Metrics v1）をそれぞれ独立節で解説
- 11 events / conditional required / `bin/plangate metrics --collect/--report/--aggregate` の CLI 例を追加
- 推測禁止条項、Roadmap PBI Issue Form、4 軸 Label taxonomy を governance 節で紹介
- 2026-05-04 baseline と後続 EPIC（v8.7.0 #196 #197 #203 #204 / v8.8.0 #198 #199 / v8.9.0 #200）を予告
- v8.5.0 の Hook 10/10 一覧は「土台」として位置を下げて残置
- CLI tests 24→32 PASS（+8 は ta-09-metrics）、Hook tests 42 PASS の事実関係を反映
- slug は `plangate-v85-hook-enforcement` のまま据え置き（既存 URL 互換）

事実関係はすべて [PlanGate CHANGELOG v8.6.0](https://github.com/s977043/plangate/blob/main/CHANGELOG.md) を一次情報として確認済み。

## Test plan
- [x] `npm run check` 実行: Zenn / Qiita validate + note ref/image lint すべて pass
- [ ] マージ後に Zenn 上でタイトル・新規節（Metrics v1 / Issue governance / Baseline）の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)