### PR TITLE
chore(qiita): sync id after PlanGate v8.6.0 publish

### DIFF
--- a/Qiita/public/plangate-ai-agent-governance.md
+++ b/Qiita/public/plangate-ai-agent-governance.md
@@ -1,14 +1,14 @@
 ---
 title: AIの止まり方を「数字で見る」ようにした体験：PlanGate v8.6.0でMetrics v1とGovernanceを入れた話
 tags:
+  - チーム開発
+  - コードレビュー
   - 生成AI
   - AI駆動開発
-  - チーム開発
   - ClaudeCode
-  - コードレビュー
 private: false
-updated_at: '2026-05-06T17:30:00+09:00'
-id: null
+updated_at: '2026-05-06T17:40:44+09:00'
+id: 5ebff79112ecf1af872c
 organization_url_name: null
 slide: false
 ignorePublish: false


### PR DESCRIPTION
## Summary
PR #190 マージ後に `npm run publish:qiita -- plangate-ai-agent-governance` を実行。
Qiita-CLI が frontmatter を自動更新したため main へ取り込む。

- `id: null` → `5ebff79112ecf1af872c`
- `tags`: Qiita 側でソートされた順に並べ替え
- `updated_at`: 2026-05-06T17:40+09:00

## 公開 URL
https://qiita.com/<author>/items/5ebff79112ecf1af872c

## Test plan
- [x] Qiita publish 成功（`Posted: plangate-ai-agent-governance -> 5ebff79112ecf1af872c / Successful!`）
- [ ] マージ後 Qiita 上で記事が一般公開状態か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)