### PR TITLE
docs(ops): introduce release/zenn deploy branch policy for rate-limit control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,42 @@ Zenn 記事の場合、`note.com/mine_unilabo` へのリンクは `npm run check
   - 個別改訂が必要になった場合は個別 PR で対応する前提も明記
   - 理由不在のバンドル PR は、将来の読者・エージェントが粒度判断を追跡できなくなる
 
+## Zenn 公開フロー（release/zenn ブランチ経由）
+
+Zenn は **`release/zenn` ブランチ** をデプロイ対象とする運用に変更（rate-limit 対策）。`main` への push は Zenn deploy をトリガーしない。
+
+```
+main                      ← 通常運用（記事執筆、レビュー反映、修正、note/Qiita 編集すべて）
+  └─ release/zenn         ← Zenn deploy 対象。このブランチへの push のみ deploy 発火
+       ← cherry-pick / merge       ← 公開準備が整った記事だけ意図的に流す
+```
+
+### 公開ルール
+
+- **1 PR で `release/zenn` にマージする記事数は最大 3 本**まで（24h/5本 rate-limit に対する安全マージン）
+- **`release/zenn` への merge は 24 時間あけて** 実施（連続バッチを避ける）
+- **既存公開記事の update は単独 PR で `release/zenn` に流す**（新規 publish と分離。update が rate-limit に巻き込まれて公開済記事が古いままになる事故を防ぐ）
+- main → release/zenn の merge は **squash 推奨**（記事単位での切り戻しを容易に）
+- 緊急時の escape: `release/zenn` への直接 push（事後で main に必ず取り込む）
+
+### 公開フロー例
+
+```
+[新規記事公開]
+1. PR1: docs/foo → main（記事執筆・レビュー反映、Zenn deploy 発火しない）
+2. PR2: release/zenn-publish-YYYY-MM-DD → release/zenn（公開対象記事だけを cherry-pick or filtered merge）
+
+[既存公開記事の update]
+1. PR1: docs/fix-typo → main（修正反映、Zenn deploy 発火しない）
+2. PR2: release/zenn-update-<slug> → release/zenn（単独 PR で update を流す。新規 publish と同 PR にしない）
+```
+
+### rate-limit hit 時の対処
+
+- リポジトリ側に追加 commit を **作らない**（被害拡大を防ぐ）
+- [Zenn お問い合わせフォーム](https://zenn.dev/inquiry) で緩和申請（公式が「移行・特殊用途では緩和可」と明言している正規ルート）
+- 詳細仕様と緩和申請文案テンプレ: `memory/reference_zenn_rate_limit_spec.md`
+
 ## Commit Attribution
 
 AIエージェントによるコミットは、利用中モデルの名前で `Co-Authored-By` を付与する。モデルが切り替わった場合は実際に使用したモデル名を反映すること（ハードコードを古いまま残さない）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,9 @@ python3 .claude/skills/note-export-import/scripts/verify_wxr.py articles_note/bu
 4. 対象ファイルがどのプラットフォームか確認（`@AGENTS.md` の配置規約表）
 5. `articles_note/published/` を触る場合は ⚠️ 規約を確認（`@AGENTS.md` 禁止事項）
 6. note 記事に画像を追加する場合: SVG → PNG 変換 → `articles_note/assets/` 配置 → **`file` でサイズ・寸法を確認**（プレースホルダ画像 <10KB を弾く） → main に先にマージ → WXR 生成の順序を守る。**WXR 生成は必ず `--base-url https://raw.githubusercontent.com/s977043/my-blog/main/articles_note/assets` を付ける**（未指定で画像参照が残ると `md_to_wxr.py` が exit 1 で失敗、意図的にローカル参照を残すなら `--allow-local-images`）
-7. 既存 Skill / Agent / Command で対応できないか確認（上記表）
-8. `@AGENT_LEARNINGS.md` で類似タスクの落とし穴を確認
+7. **Zenn 公開系の作業を進める前に**、`@AGENTS.md` の「Zenn 公開フロー（release/zenn ブランチ経由）」を確認。`articles/*.md` の `published: true` 切替や本文修正は **`release/zenn` ブランチへの merge をもって公開**となる。`main` への push は Zenn deploy をトリガーしない（rate-limit 対策）。1 PR 最大 3 本 / 24 時間あけてマージ / 既存 update と新規 publish は別 PR、を厳守
+8. 既存 Skill / Agent / Command で対応できないか確認（上記表）
+9. `@AGENT_LEARNINGS.md` で類似タスクの落とし穴を確認
 
 ## 並列実行の指針
 


### PR DESCRIPTION
## Summary
Zenn の rate-limit (24h/5本) 連続 hit を構造的に防ぐため、Zenn デプロイ対象ブランチを `main` から `release/zenn` に分離する運用ポリシーを正本化する。

## 背景
2026-05-06〜07 に Codex によるレビュー反映を集中実施 → 24 時間以内に Zenn publish 系 PR を 5 本連続マージ → **7 記事すべてが rate-limit でデプロイされず**、既公開記事の更新（`plangate-v86-hook-enforcement`）まで巻き添えで未反映。手動デプロイでもキューは解放されないことを実観測。

main 直結だと、レビュー反映 / 修正 / 既存記事 update / 新規 publish がすべて Zenn deploy トリガーとなり、rate-limit を発火させやすい。

## 変更内容

### 1. AGENTS.md に「Zenn 公開フロー（release/zenn ブランチ経由）」セクション追加
- `main` = 通常運用（記事執筆・レビュー反映・修正すべて）
- `release/zenn` = Zenn deploy 対象（このブランチへの push のみ deploy 発火）
- **1 PR 最大 3 本まで / 24h あけてマージ / 既存 update と新規 publish は別 PR**
- rate-limit hit 時は追加 commit を作らず [Inquiry](https://zenn.dev/inquiry) で緩和申請

### 2. CLAUDE.md 作業開始時チェックリストに項目追加
- 「Zenn 公開系作業前に release/zenn ブランチ運用を確認」を新項目 7 として挿入
- 既存 7-8 を 8-9 に繰り下げ

## 別途必要なアクション

### あなた側（リポジトリ外）
- [ ] Zenn ダッシュボード「設定を変更」→ デプロイ対象ブランチを `main` → `release/zenn` に切替

### リポジトリ側（実施済）
- [x] `release/zenn` ブランチを main から派生して push 済（本 PR の前段で実施、commit hash `57272be` から派生）

## 注意点
本 PR 自体は通常通り main にマージ。Zenn ダッシュボード切替前は main 直結のまま deploy 発火する点に注意。ただし AGENTS.md/CLAUDE.md は Zenn 公開対象ファイルではないため Zenn deploy 対象外。

## Test plan
- [x] `npm run check`: Zenn / Qiita validate + note ref/image lint すべて pass
- [ ] Zenn 設定切替後、main への通常 push が deploy 発火しないことを確認
- [ ] release/zenn への merge が deploy 発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)