### PR TITLE
docs: revise Zenn rollout plan & add AGENT_LEARNINGS for rate-limit

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -627,6 +627,52 @@ note公式ヘルプには「`https://` URLの JPEG/PNG/GIF なら `<img>` で取
 
 ---
 
+### 2026-05-07 — Zenn rate-limit はアカウント単位、ブランチ切替・手動デプロイ・追加 commit のいずれでも解放されない [Incident] [Convention] [Workflow]
+
+**観察**: 2026-05-06〜07 に Codex によるレビュー反映を集中マージし、24 時間以内に Zenn publish 系 PR を 5 本連続マージ → **7 記事すべてが rate-limit でデプロイされず**、既公開記事 `plangate-v86-hook-enforcement` の更新まで巻き添えで未反映状態になった。リポジトリ側で複数の解消策を試したが、**いずれもキューを解放できなかった**:
+
+- 追加 commit を 5 件 push（12 時間以上経過） → リスト不変
+- Zenn ダッシュボード「手動デプロイ」 → リスト不変
+- デプロイ対象ブランチ切替（main → release/zenn） → リスト不変
+
+ブランチ切替後の release/zenn deploy 試行で **完全に同じ 7 記事リスト**が表示されたことから、rate-limit キューは **アカウント単位で維持** されており、ブランチ単位ではないと結論。
+
+**対策/学び**:
+- **Zenn デプロイ対象ブランチを `main` から `release/zenn` に分離**する（rate-limit 再発防止の構造的対策、PR #199 で AGENTS.md/CLAUDE.md に正本化）
+  - main = 通常運用（記事執筆・レビュー反映・修正すべて、Zenn deploy 発火しない）
+  - release/zenn = Zenn deploy 対象（このブランチへの push のみ deploy 発火）
+- **release/zenn への merge は 24h あけて 1 PR 最大 3 本まで**（5 本上限に対する安全マージン）
+- **既存公開記事の update PR と新規 publish PR は分離**（update が rate-limit に巻き込まれる事故を防ぐ）
+- **rate-limit hit を検知したら追加 commit を作らない**（被害拡大を防ぐ）
+- 解消手段は **時間経過による Zenn 側自動解放を待つ** または [Zenn お問い合わせフォーム](https://zenn.dev/inquiry) から緩和申請（Zenn 公式が「移行・特殊用途では緩和可」と明言）
+- ⚠️ **派生時点の状態に注意**: `release/zenn` を `main` から派生する際、派生元 main の `published: true` が release/zenn にも引き継がれる。派生時点で複数記事が published であれば、それらは release/zenn 上でも published 扱い → 切替直後に rate-limit 対象になる可能性。事前に該当記事の published 状態を確認してから派生する
+
+**根拠**: 2026-05-06〜07 セッション。PR #193〜#198 で rate-limit hit、PR #199（ブランチ分離ポリシー）/ PR #200（rollout plan）で構造的対策を反映。詳細仕様: `memory/reference_zenn_rate_limit_spec.md`、運用ルール: `memory/feedback_zenn_publish_rate_pacing.md`
+
+---
+
+### 2026-05-07 — Zenn ダッシュボード設定切替後は既存ブランチを派生元の状態と整合させる [Workflow] [Pattern]
+
+**観察**: Zenn デプロイ対象ブランチを main → release/zenn に切り替えた直後、release/zenn は派生元 main の `published: true` をすべて引き継いでいた。「Phase 1 で plangate-v86 だけを段階公開する」と計画していたが、**既に release/zenn 上に 7 記事すべてが published で乗っている**ため、段階公開そのものが不可能と判明。
+
+**対策/学び**:
+- **新規ブランチを Zenn deploy 対象にする前に、派生元の `published: true` 記事一覧を grep で確認**:
+  ```bash
+  for f in articles/*.md; do
+    v=$(awk '/^published:/{print $2; exit}' "$f")
+    [ "$v" = "true" ] && echo "$(basename "$f")"
+  done
+  ```
+- 段階公開を実装する場合の選択肢:
+  - **A.** 派生時に `published: true` 記事を `false` に一括書き戻して push し、段階的に true に切り替える（手数大、main との整合性管理が複雑）
+  - **B.** 派生は通常通り行い、待機戦略（自然解放）に切り替える（実用的、本セッションで採用）
+  - **C.** 公開対象が少数なら、派生元 main 上で `published: false` に戻してから派生 → release/zenn 切替（段階公開向き、ただし main の履歴が複雑化）
+- **計画を立てる前に、対象ブランチの実際の状態を grep / git show で必ず確認**（前提を確認せずに計画を作ると、後から書き直しになる）
+
+**根拠**: 2026-05-07 セッション。PR #200（誤った Phase 1〜3 計画書）→ 同日に PR で全面修正。`docs/zenn-release-rollout-plan.md` の改訂履歴
+
+---
+
 <!--
 ## 追加時のテンプレート
 

--- a/docs/zenn-release-rollout-plan.md
+++ b/docs/zenn-release-rollout-plan.md
@@ -1,8 +1,10 @@
-# Zenn Release Rollout Plan — 2026-05-07 rate-limit 解消後の段階公開計画
+# Zenn Release Rollout Plan — 2026-05-07 rate-limit 解消後の運用計画
+
+> **本ドキュメントは 2026-05-07 17:00 GMT+9 に全面改訂しました。** 旧版（同日 PR #200）の「Phase 1〜3 で段階的に release/zenn に流す」計画は、release/zenn 上に既に 7 記事すべて `published: true` で乗っていることが事後確認で判明したため成立しません。
 
 ## 1. 背景
 
-2026-05-06〜07 にかけて、Codex によるレビュー反映を集中的に実施した結果、24 時間以内に Zenn publish 系 PR を 5 本連続マージ → **7 記事すべてが Zenn rate-limit でデプロイされず**、既公開記事の更新（`plangate-v86-hook-enforcement`）まで巻き添えで未反映状態になった。
+2026-05-06〜07 にかけて、Codex によるレビュー反映を集中的に実施した結果、24 時間以内に Zenn publish 系 PR を 5 本連続マージ → **7 記事すべてが Zenn rate-limit でデプロイされず**、既公開記事 `plangate-v86-hook-enforcement` の更新まで巻き添えで未反映状態になった。
 
 実観測の結論:
 
@@ -12,19 +14,22 @@
 | Zenn ダッシュボード「手動デプロイ」 | キュー解放されず |
 | デプロイ対象ブランチ切替（main → release/zenn） | **キューはアカウント単位で維持されており解放されず** |
 
-→ リポジトリ側からの操作では rate-limit キュー解放は不可能。**Zenn 側の自然解放を待つ**方針に確定（Inquiry 申請は本セッションでは実施しない判断）。
+→ リポジトリ側からの操作では rate-limit キュー解放は不可能。**Zenn 側の自然解放を待つ**方針に確定（Inquiry 申請は本セッションでは見送り）。
 
-詳細仕様: `memory/reference_zenn_rate_limit_spec.md`
+詳細仕様: `memory/reference_zenn_rate_limit_spec.md` / `AGENT_LEARNINGS.md` 2026-05-07 エントリ
 
-## 2. 現状の確定事項
+## 2. 現状の確定事項（重要）
 
 | 項目 | 状態 |
 |---|---|
 | Zenn デプロイ対象ブランチ | `release/zenn`（2026-05-07 切替済） |
 | `release/zenn` HEAD | `57272be`（cover.jpg 復旧時点） |
-| `main` HEAD | 最新（PR #199 ポリシー文書込み） |
-| rate-limit 該当 7 記事の `published: true` 切替 | main にあり、release/zenn にはまだ無し（Phase 1 以降で流す） |
+| `main` HEAD | 最新（PR #199 ポリシー文書 / PR #200 旧計画書 / 本 PR の改訂版込み） |
+| **release/zenn 上の rate-limit 7 記事の状態** | **すべて `published: true`**（派生時点で main から引き継ぎ済） |
+| main と release/zenn の差分 | docs / AGENTS.md / CLAUDE.md のポリシー文書のみ（記事は同状態） |
 | 構造的対策 | PR #199 で AGENTS.md / CLAUDE.md にポリシー正本化済 |
+
+⚠️ **段階公開は構造上不可能**: release/zenn には既に 7 記事すべてが published 状態で存在しているため、「Phase 1 で plangate-v86 だけを流す」「Phase 2 で 3 本」という段階分離はできません。すべて同じキューに乗っており、Zenn 側で順次解放される（推測：24h あたり 5 本まで）のを待つしかありません。
 
 ## 3. 解放検知方法
 
@@ -32,119 +37,85 @@
 
 Zenn ダッシュボードのデプロイログで **「お知らせ」セクションの 7 記事リスト**を確認:
 
-- 7 記事すべて残留 → 未解放、待機継続
-- 一部減少 → 部分解放（Phase 1 から段階的に進められる）
-- 「お知らせ」自体が出なくなる → 完全解放（Phase 1 着手可）
-
-### 軽微な探り push
-
-週 1 程度で `release/zenn` に軽微な commit（例: README 更新）を push し、deploy ログで rate-limit 表示が消えたか確認する。push 自体が再 trigger になる可能性があるため、**ペースは慎重に**（24h 以上あけて 1 回まで）。
-
-## 4. 段階公開計画（解放確認後に着手）
-
-### Phase 1: 既存公開記事の最優先 update
-
-| 項目 | 内容 |
+| 観測 | 判定 |
 |---|---|
-| 対象 | `articles/plangate-v86-hook-enforcement.md`（更新内容: PR #194 hook count fix + PR #197 Codex review fixes） |
-| 流す PR ブランチ | `release/zenn-update-plangate-v86` |
-| マージ先 | `release/zenn` |
-| 理由 | 既存公開記事の更新は最優先。読者から見ると古い情報が表示されている影響が大きい |
-| 実行コマンド | 下記 §5 参照 |
+| 7 記事すべて残留 | 未解放、待機継続 |
+| 一部減少（例: 5 記事に減) | 部分解放（Zenn が 24h あたり 5 本まで処理した可能性） |
+| 「お知らせ」自体が出なくなる | 完全解放 |
 
-### Phase 2: 新規公開 3 本（Phase 1 から 24h あけて）
+### 部分解放のサイン
 
-| 項目 | 内容 |
-|---|---|
-| 対象 | `ai-legible-repository-design` / `codex-developer-instructions` / `plangate-design-evolution-v3-to-v8` |
-| 流す PR ブランチ | `release/zenn-publish-batch1` |
-| マージ先 | `release/zenn` |
-| 選定理由 | Codex review で READY または Medium 反映済の 3 本を優先 |
+24h あたり 5 本上限の場合、解放後に Zenn が処理する順序は不明。次のいずれかが起きる:
 
-### Phase 3: 残り新規 3 本（Phase 2 から 24h あけて）
+- 古いキュー順（最初に hit した順）から 5 本 deploy → 残り 2 本がまた次のウィンドウへ
+- 新しい順 / アルファベット順 / その他基準で 5 本 → 残り 2 本
 
-| 項目 | 内容 |
-|---|---|
-| 対象 | `ai-article-quality-gate-workflow` / `ai-driven-dev-metrics` / `seo-sns-article-design-ai-workflow` |
-| 流す PR ブランチ | `release/zenn-publish-batch2` |
-| マージ先 | `release/zenn` |
+部分解放を検知したら **release/zenn には何も push しない**で、次の 24h ウィンドウを待つ。push すると新しい hit 対象が追加される可能性。
 
-## 5. 実行コマンド（参考）
+### 軽微な探り push（最終手段）
 
-各 Phase で実行する典型コマンド。
+48h 経過しても変化がない場合、release/zenn に **記事以外** の軽微な commit（README やコメントの 1 行修正）を push して deploy 試行を発生させ、現在のキュー状態を確認する。**記事ファイルは触らない**こと。
 
-### Phase 1（plangate-v86 update のみ）
+## 4. 解放後にできること
 
-```bash
-# release/zenn から派生
-git switch release/zenn
-git pull --ff-only
-git switch -c release/zenn-update-plangate-v86
+### 完全解放後（7 記事すべて deploy 成功）
 
-# main の該当ファイルを取り込む
-git checkout main -- articles/plangate-v86-hook-enforcement.md
+- 各記事の URL をブラウザで目視確認
+- `plangate-v86-hook-enforcement` のタイトル / TL;DR が最新内容（v8.6.0 の Metrics v1 と Governance）であること
+- 新規 6 記事が Zenn 検索に出ること
 
-# 整合性検証
-npm run check
+### release/zenn を main に追従させる（オプション）
 
-# commit
-git add articles/plangate-v86-hook-enforcement.md
-git commit -m "release(zenn): apply plangate-v86 update (PR #194 + #197 fixes)"
-
-# push & PR（base は release/zenn）
-git push -u origin release/zenn-update-plangate-v86
-gh pr create --base release/zenn --head release/zenn-update-plangate-v86 \
-  --title "release(zenn): plangate-v86 hook count + Codex review fixes" \
-  --body "Phase 1: 既存公開記事 plangate-v86-hook-enforcement の最優先 update。"
-```
-
-### Phase 2（新規 3 本、Phase 1 から 24h 後）
+完全解放後、release/zenn に main の docs / AGENTS.md / CLAUDE.md 更新を取り込みたい場合:
 
 ```bash
 git switch release/zenn
 git pull --ff-only
-git switch -c release/zenn-publish-batch1
-
-git checkout main -- \
-  articles/ai-legible-repository-design.md \
-  articles/codex-developer-instructions.md \
-  articles/plangate-design-evolution-v3-to-v8.md
-
-npm run check
-git add articles/
-git commit -m "release(zenn): publish batch1 (3 articles)"
-git push -u origin release/zenn-publish-batch1
-gh pr create --base release/zenn --head release/zenn-publish-batch1 \
-  --title "release(zenn): publish 3 articles (Phase 2)" \
-  --body "Phase 2: ai-legible-repository-design / codex-developer-instructions / plangate-design-evolution-v3-to-v8"
+git merge main --no-ff -m "merge: sync docs and policy from main"
+git push origin release/zenn
 ```
 
-### Phase 3（残り 3 本、Phase 2 から 24h 後）
+注意: この merge にはドキュメント更新のみ含まれ、記事ファイルには変更が入らない（既に release/zenn 側でも main 側でも同じ状態）。Zenn deploy 通知は出るが「お知らせ」セクションは空のはず。
+
+## 5. 今後の Zenn 公開フロー（解放後の通常運用）
+
+### 新規記事公開
 
 ```bash
+# main で執筆・レビュー反映（Zenn deploy 発火しない）
+git switch main
+git switch -c docs/new-article-foo
+# ... 編集 ...
+git push origin docs/new-article-foo
+gh pr create --base main ...
+
+# main マージ後、release/zenn に流す（Zenn deploy 発火）
 git switch release/zenn
 git pull --ff-only
-git switch -c release/zenn-publish-batch2
-
-git checkout main -- \
-  articles/ai-article-quality-gate-workflow.md \
-  articles/ai-driven-dev-metrics.md \
-  articles/seo-sns-article-design-ai-workflow.md
-
+git switch -c release/zenn-publish-foo
+git checkout main -- articles/foo.md  # 該当ファイルだけ取り込み
 npm run check
-git add articles/
-git commit -m "release(zenn): publish batch2 (3 articles)"
-git push -u origin release/zenn-publish-batch2
-gh pr create --base release/zenn --head release/zenn-publish-batch2 \
-  --title "release(zenn): publish 3 articles (Phase 3)" \
-  --body "Phase 3: ai-article-quality-gate-workflow / ai-driven-dev-metrics / seo-sns-article-design-ai-workflow"
+git add articles/foo.md
+git commit -m "release(zenn): publish foo"
+git push -u origin release/zenn-publish-foo
+gh pr create --base release/zenn --head release/zenn-publish-foo ...
 ```
+
+### 既存公開記事の更新
+
+新規 publish と **同じ PR にしない**。単独で release/zenn に流す。
+
+### ペース制約
+
+- 1 PR で release/zenn に merge する記事数 **最大 3 本**
+- release/zenn への merge は **24h あけて** 実施
+- 既存 update PR と新規 publish PR は **別日**
 
 ## 6. リスクと中断条件
 
 ### 中断条件
 
-各 Phase 後、Zenn ダッシュボードで以下を確認し、該当する場合は **次の Phase を中断**:
+各 release/zenn merge 後、Zenn ダッシュボードで以下を確認し、該当する場合は **次の merge を中断**:
 
 - マージ後 24h 以内に **deploy 反映が確認できない** → rate-limit 再 hit の疑い
 - 「お知らせ」セクションに **新しい slug が追加された** → ペース超過
@@ -154,15 +125,15 @@ gh pr create --base release/zenn --head release/zenn-publish-batch2 \
 
 1. release/zenn への追加 commit を停止（被害拡大防止）
 2. 24-48h 待機して再確認
-3. 解消しない場合は Inquiry 申請の再検討
+3. 解消しない場合は Inquiry 申請を再検討
 
 ### リスク
 
 | リスク | 影響度 | 緩和策 |
 |---|---|---|
-| Phase 2 / Phase 3 で再び rate-limit hit | 高 | 24h 厳守、3 本/PR 上限厳守 |
-| Phase 間の 24h 待機中に main で急ぎの記事修正 | 中 | main で作業 → release/zenn には次の Phase で取り込み（ブランチ分離が機能） |
-| 既存公開 25 記事への影響 | 低 | release/zenn 切替直後に変動なしを確認済（実観測） |
+| 自然解放のタイミングが不透明 | 高 | 24h ごとに観察、長期化したら Inquiry 申請 |
+| 解放後の Phase 2 / Phase 3 で再 rate-limit hit | 中 | 24h 厳守、3 本/PR 上限厳守 |
+| release/zenn と main の docs 差分が放置される | 低 | 解放後に merge で同期（記事には影響なし） |
 
 ## 7. 完了条件
 
@@ -174,6 +145,12 @@ gh pr create --base release/zenn --head release/zenn-publish-batch2 \
 
 - `AGENTS.md` §「Zenn 公開フロー（release/zenn ブランチ経由）」
 - `CLAUDE.md` §「作業開始時のチェックリスト」項目 7
+- `AGENT_LEARNINGS.md` 2026-05-07 「Zenn rate-limit はアカウント単位...」「Zenn ダッシュボード設定切替後は既存ブランチを派生元の状態と整合させる」
 - `memory/feedback_zenn_publish_rate_pacing.md` — 24h あたり 3 本までの運用ルール
 - `memory/reference_zenn_rate_limit_spec.md` — Zenn rate-limit 仕様、キュー残留挙動、緩和申請手順
-- 関連 PR: #193, #194, #195, #196, #197, #198, #199
+- 関連 PR: #193, #194, #195, #196, #197, #198, #199, #200
+
+## 9. 改訂履歴
+
+- 2026-05-07 17:00 GMT+9: PR #200 の旧版（誤った Phase 1〜3 計画）を全面改訂。release/zenn には既に 7 記事すべてが published で乗っている事実を確認したため、段階公開戦略を「待機 + 解放後確認」に変更
+- 2026-05-07 04:00 GMT+9: PR #200 で初版作成


### PR DESCRIPTION
## Summary
PR #200 の旧版段階公開計画は前提誤りだったため全面改訂し、合わせて学びを AGENT_LEARNINGS.md に正本化する。

## 旧版の前提誤り
- 旧版（PR #200）は「Phase 1 で plangate-v86 だけを release/zenn に流す」と計画
- 実際の release/zenn は main の 57272be (PR #198) から派生 → PR #195/#196/#197 がすでにマージされた状態のため、release/zenn 上に **7 記事すべてが published: true で乗っている** ことが事後確認で判明
- 段階公開そのものが構造上不可能（既に全部 release/zenn にある）

## 改訂内容

### 1. docs/zenn-release-rollout-plan.md
- 段階公開（Phase 1〜3）戦略を「待機 + 解放後確認」に全面変更
- §2 で release/zenn 上に 7 記事すべてが published で存在することを明記
- §4 解放後にできること、§5 解放後の通常運用フロー、§6 中断条件を整理
- §9 改訂履歴セクション追加

### 2. AGENT_LEARNINGS.md 追記（2 件）
- **2026-05-07** Zenn rate-limit はアカウント単位、ブランチ切替・手動デプロイ・追加 commit のいずれでも解放されない（実観測ベースの結論と再発防止策）
- **2026-05-07** Zenn ダッシュボード設定切替後は既存ブランチを派生元の状態と整合させる（派生時点の published 引き継ぎを事前確認する grep スニペット）

## 関連
- PR #199: AGENTS.md / CLAUDE.md にブランチ運用ポリシー正本化
- PR #200: 旧版計画書（本 PR で改訂対象）
- memory/feedback_zenn_publish_rate_pacing.md: 24h あたり 3 本ルール
- memory/reference_zenn_rate_limit_spec.md: rate-limit 仕様

## Test plan
- [x] npm run check: Zenn / Qiita validate + note ref/image lint すべて pass
- [x] 旧版前提誤りの根拠を grep / git show で確認済（release/zenn 上の 7 記事すべて published: true）
- [ ] マージ後 Zenn ダッシュボードで release/zenn の deploy 状態確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)