### PR TITLE
docs(articles): sync README to release/zenn deploy branch policy

### DIFF
--- a/articles/README.md
+++ b/articles/README.md
@@ -35,9 +35,11 @@ published: false          # trueにすると公開
 | 状態 | `published` | 挙動 |
 | ---- | ----------- | ---- |
 | ローカル下書き | `false` | ローカルプレビューのみ |
-| 一般公開 | `true` | `git push`でZennに反映 |
+| 一般公開 | `true` | `release/zenn` ブランチへの merge で Zenn に反映 |
 
-ZennはGitHub連携方式のため、`publish`用のコマンドは不要。`main`へのpushで自動デプロイされる。
+ZennはGitHub連携方式のため、`publish`用のコマンドは不要。**デプロイ対象ブランチは `release/zenn`**（rate-limit 対策で 2026-05-07 切替、PR #199）。`main` への push は Zenn deploy をトリガーしない。
+
+公開フロー全体（1 PR 最大 3 本 / 24h あけてマージ / 既存 update と新規 publish は別 PR）は `AGENTS.md` §「Zenn 公開フロー（release/zenn ブランチ経由）」を参照。rate-limit 仕様と緩和申請手順は `memory/reference_zenn_rate_limit_spec.md` にある。
 
 ## よく使うコマンド
 


### PR DESCRIPTION
## Summary
ドキュメント横断検証（整合性・鮮度・網羅性・重複・導線の 5 観点）で発見した、`articles/README.md` の古い記述（main 直結 deploy 前提）を release/zenn 運用に整合する。

## 検出経緯
2026-05-07 のドキュメント検証セッションで、AGENTS.md / CLAUDE.md / AGENT_LEARNINGS.md / docs/zenn-release-rollout-plan.md / memory はすべて release/zenn 運用反映済だが、**サブディレクトリ README (articles/README.md) のみ更新漏れ**だったことが判明。

## 修正内容（articles/README.md L37-L41）

| 修正前 | 修正後 |
|---|---|
| `git push でZennに反映` | `release/zenn ブランチへの merge で Zenn に反映` |
| `main への push で自動デプロイされる` | `デプロイ対象ブランチは release/zenn。main への push は Zenn deploy をトリガーしない` |
| ナビゲーションリンクなし | AGENTS.md §「Zenn 公開フロー」と `memory/reference_zenn_rate_limit_spec.md` への明示的リンク追加 |

## 検証で確認した整合済ドキュメント（修正不要）
- `AGENTS.md` §102 「Zenn 公開フロー（release/zenn ブランチ経由）」
- `CLAUDE.md` §69 作業開始時のチェックリスト項目 7
- `AGENT_LEARNINGS.md` 2026-05-07 「Zenn rate-limit はアカウント単位...」
- `docs/zenn-release-rollout-plan.md`（PR #200 → 改訂 PR #201）
- `memory/feedback_zenn_publish_rate_pacing.md`
- `memory/reference_zenn_rate_limit_spec.md`
- `Qiita/README.md`（qiita-cli 経由のため release/zenn 影響なし）
- `articles_note/README.md`（WXR 経由のため影響なし）

## Test plan
- [x] `npm run check`: Zenn / Qiita validate + note ref/image lint すべて pass
- [x] 検証 5 観点（整合性 / 鮮度 / 網羅性 / 重複 / 導線）で本 PR 後に追加修正必要箇所がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)