### PR TITLE
chore: ignore .vscode/ (IDE local history)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ articles_note/build/
 # Python バイトコードキャッシュ (note-export-import スクリプト実行で生成)
 __pycache__/
 *.pyc
+
+# VS Code Local History 拡張等の IDE 生成物 (ワークツリー状態を汚さない)
+.vscode/


### PR DESCRIPTION
## Summary

- `.gitignore` に `.vscode/` を追加し、VS Code の Local History 拡張が生成する `.vscode/.history/` を `git status` のノイズから除外。

## Why

- セッション開始時に `.vscode/` が untracked として常に残り、誤って commit に混入しうる。
- IDE 生成物のためコミット対象とすべきではない。

## Verification

- `git status --short` 実行で `.vscode/` がリストから消えることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)