### PR TITLE
fix(article): shorten river-reviewer v0.33 title to fit Zenn 70-char limit

### DIFF
--- a/articles/river-reviewer-v033-improvement-loop.md
+++ b/articles/river-reviewer-v033-improvement-loop.md
@@ -1,5 +1,5 @@
 ---
-title: 'River Reviewer v0.30.0 → v0.33.0：Skill Improvement Loop と applyTo Scoping を整備した半月の記録'
+title: 'River Reviewer v0.30→v0.33：Improvement Loop と applyTo Scoping 整備の半月'
 emoji: '🌊'
 type: 'tech'
 topics: ['ai', 'codereview', 'AgentSkills', 'AI駆動開発', 'oss']


### PR DESCRIPTION
## Summary

Zenn デプロイログで「`articles/river-reviewer-v033-improvement-loop.md` の保存に失敗しました（Titleには最大70文字まで使用できます）」が発生したため、タイトルを **84 → 67 文字**に短縮する。

## Before / After

```
Before (84 chars):
  River Reviewer v0.30.0 → v0.33.0：Skill Improvement Loop と applyTo Scoping を整備した半月の記録

After (67 chars):
  River Reviewer v0.30→v0.33：Improvement Loop と applyTo Scoping 整備の半月
```

## 短縮ポイント

| 変更前 | 変更後 | 削減 |
|---|---|---|
| `v0.30.0 → v0.33.0` | `v0.30→v0.33` | 5 文字 |
| `Skill Improvement Loop` | `Improvement Loop` | 6 文字 |
| `を整備した半月の記録` | `整備の半月` | 6 文字 |

主要トピック（Improvement Loop / applyTo Scoping / 半月）は保持。

## Verification

- 文字数: Python での実測で 67 文字（70 上限内、3 文字の余裕）
- `npm run check` グリーン

## Notes

- `published: false` 据え置き（公開判断は別ラウンド）
- 本 PR マージ後、`release/zenn` への sync PR を別途起票してデプロイ失敗を解消する
- 並行して rate-limit hit 6 記事は自然解放待ち（本 PR の対象外）