### PR TITLE
chore(process): add check:zenn-title automated guard for 70-char title limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "check:note-images": "node scripts/check-note-images.js",
     "check:doc-freshness": "node scripts/check-doc-freshness.js",
     "check:zenn-pace": "node scripts/check-zenn-publish-pace.js",
-    "check": "npm run list:articles && npm run list:books && npm run check:qiita && npm run check:note-ref && npm run check:note-images && npm run check:doc-freshness"
+    "check:zenn-title": "node scripts/check-zenn-title-length.js",
+    "check": "npm run list:articles && npm run list:books && npm run check:qiita && npm run check:note-ref && npm run check:note-images && npm run check:doc-freshness && npm run check:zenn-title"
   },
   "dependencies": {
     "zenn-cli": "^0.4.7"

--- a/scripts/check-zenn-title-length.js
+++ b/scripts/check-zenn-title-length.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Check: articles/*.md の frontmatter `title` が Zenn 70 文字上限以内か検査する。
+// Zenn は 70 文字を超えるタイトルでデプロイ保存に失敗する仕様。
+//
+// 使い方: `npm run check:zenn-title` 単独実行、または `npm run check` で他チェックと一括実行。
+//
+// 経緯: 2026-05-08、`articles/river-reviewer-v033-improvement-loop.md` のタイトルが
+//       84 文字で Zenn デプロイログに「Titleには最大70文字まで使用できます」が出て保存失敗。
+//       3ラウンドのレビューを通過したのに事前検出できなかったため、自動ガード化する。
+//
+// 詳細: AGENTS.md §「Zenn 公開フロー」、PR #215
+
+const fs = require('fs');
+const path = require('path');
+
+const LIMIT = 70;
+const ARTICLES_DIR = path.join(__dirname, '..', 'articles');
+
+function extractTitle(content) {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+  const fm = fmMatch[1];
+  const titleLine = fm.split('\n').find((line) => line.startsWith('title:'));
+  if (!titleLine) return null;
+  // title: 'foo' / title: "foo" / title: foo の3形式に対応
+  const m = titleLine.match(/^title:\s*(?:'([^']*)'|"([^"]*)"|(.*))\s*$/);
+  if (!m) return null;
+  return (m[1] ?? m[2] ?? m[3] ?? '').trim();
+}
+
+function main() {
+  if (!fs.existsSync(ARTICLES_DIR)) {
+    console.log('[check:zenn-title] articles/ ディレクトリが見つからないためスキップ');
+    return;
+  }
+
+  const files = fs
+    .readdirSync(ARTICLES_DIR)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md');
+
+  const violations = [];
+  for (const f of files) {
+    const fullPath = path.join(ARTICLES_DIR, f);
+    const content = fs.readFileSync(fullPath, 'utf8');
+    const title = extractTitle(content);
+    if (title === null) {
+      // frontmatter または title 行が無い記事はスキップ（README など）
+      continue;
+    }
+    if (title.length > LIMIT) {
+      violations.push({ file: f, length: title.length, title });
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log(`[check:zenn-title] OK: 全 ${files.length} 記事のタイトルが ${LIMIT} 文字以内`);
+    return;
+  }
+
+  console.error(`[check:zenn-title] FAIL: ${violations.length} 件のタイトルが ${LIMIT} 文字を超過`);
+  for (const v of violations) {
+    console.error(`  ${v.file} (${v.length} chars)`);
+    console.error(`    ${v.title}`);
+  }
+  console.error('');
+  console.error(
+    '  対処: タイトルを ' + LIMIT + ' 文字以内に短縮する。Zenn は 70 文字を超えるタイトルでデプロイ保存に失敗する。',
+  );
+  console.error('  詳細: PR #215 を参照');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

直前セッション（2026-05-08）の振り返りから、致命的インシデント（PR #215：Zenn 70 文字上限超過によるデプロイ保存失敗）の再発防止を **自動ガード（B）** として実装する。

## 振り返り表

### ✅ うまくいったこと
- 各タスクで実行計画を提示してから自走できた
- stash クリーンアップでユーザー判断を仰ぎつつ退避ブランチ運用で安全に保管→取り込み→削除
- release/zenn 同期 PR で publish 切替 0 件を事前検証して rate-limit 消費を回避
- Zenn 70 文字上限エラーをユーザーから共有された時点で即座に進行中の sync 作業を破棄してタイトル修正を最優先化

### ⚠️ 改善が必要だったこと

| # | 問題 | 発生箇所 | 影響 |
|---|---|---|---|
| 1 | river-reviewer 記事のタイトル長過（84 文字）を 3 ラウンドのレビューで検出できなかった | PR #203 → #213 → #214 | **致命的**: Zenn デプロイ保存失敗、ユーザー観測で発覚 |
| 2 | gh pr create / edit が長い HEREDOC body で `must be a collaborator` エラー（auth は s977043 active） | PR #212 / #213 / #214 | 中: 手戻り 1〜2 回／PR、簡略 body + edit で回避 |
| 3 | release/zenn 同期で add/add コンフリクト発生（前回 squash merge 由来） | sync v2 / v3 | 低: --theirs 採用で復旧、判断時間 30 秒 |

### 🚨 致命的だった問題
- Zenn 70 文字上限超過 → デプロイ保存失敗（記事公開不能、ユーザー観測で発覚）

## 改善実装（A: 自動ガード）

`scripts/check-zenn-title-length.js` を新設し、`articles/*.md` の frontmatter `title` が 70 文字を超えたら exit 1 で FAIL する。`npm run check` に統合。

## Carry-over（次セッションで継続）

| # | 項目 | 種別 |
|---|---|---|
| B | article-reviewer SKILL にタイトル長チェック観点を明示追加（subagent 側のレビュー強化） | A: ドキュメント |
| C | AGENT_LEARNINGS.md に「`gh pr create` 長 body で must-be-collaborator → 簡略 body + edit 回避」追記 | A: ドキュメント |
| D | AGENT_LEARNINGS.md に「release/zenn 同期の add/add コンフリクトは `--theirs` 一発適用」追記 | A: ドキュメント |

A（本 PR）は最優先の自動ガード化。B〜D は次回セッション開始時のタスクとして残す。

## Test plan

- [x] 正常系: `npm run check:zenn-title` 全 27 記事が 70 文字以内で OK exit 0
- [x] 異常系: 77 文字のテスト記事を一時投入 → FAIL exit 1 で正しく検出
- [x] `npm run check` で 7 チェックすべて通過

## 関連セッション

- 前回の振り返り PR: #207
- 対象セッションの PR: #208 / #210 / #211 / #212 / #213 / #214 / #215 / #216
- 致命的インシデント: PR #215（タイトル短縮で復旧、Zenn デプロイログでユーザー観測）