### PR TITLE
docs(qiita): mark River Reviewer article as published

### DIFF
--- a/Qiita/public/river-reviewer-flow-based-ai-review.md
+++ b/Qiita/public/river-reviewer-flow-based-ai-review.md
@@ -1,17 +1,17 @@
 ---
 title: AIコードレビューはPRだけ見ていていいのか？ 開発の流れ全体をレビューするOSS「River Reviewer」を作った
 tags:
-  - AI
-  - GitHubActions
-  - コードレビュー
   - 開発プロセス
+  - AI
   - OSS
-private: true
-updated_at: ""
-id: null
+  - コードレビュー
+  - GitHubActions
+private: false
+updated_at: '2026-05-11T15:28:53+09:00'
+id: 5a4665e78c4bd1a5c1bc
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
 
 # AIコードレビューはPRだけ見ていていいのか？ 開発の流れ全体をレビューするOSS「River Reviewer」を作った


### PR DESCRIPTION
## Summary\n- Reflect Qiita publish metadata for the River Reviewer flow article\n- Set the article to public and publishable in local front matter\n\n## Verification\n- npm run check\n- npm run publish:qiita -- river-reviewer-flow-based-ai-review\n\nPublished Qiita article ID: 5a4665e78c4bd1a5c1bc