### PR TITLE
docs(qiita): add related links and FAQ

### DIFF
--- a/Qiita/public/93027e02e962ec327c2f.md
+++ b/Qiita/public/93027e02e962ec327c2f.md
@@ -7,7 +7,7 @@ tags:
   - AI駆動開発
   - ClaudeCode
 private: false
-updated_at: '2026-05-11T15:52:39+09:00'
+updated_at: '2026-05-11T16:33:51+09:00'
 id: 93027e02e962ec327c2f
 organization_url_name: null
 slide: false
@@ -324,3 +324,29 @@ PlanGateは、そのための小さなガードレールとして作っていま
 - [PlanGate GitHub Repository](https://github.com/s977043/PlanGate)
 - [PlanGate README](https://github.com/s977043/PlanGate/blob/main/README.md)
 - [PlanGate CHANGELOG](https://github.com/s977043/PlanGate/blob/main/CHANGELOG.md)
+
+## FAQ
+
+### PlanGateはAIの実装速度を落とすための仕組みですか？
+
+いいえ。目的はAIを遅くすることではなく、実装前にスコープ、テスト観点、リスクを確認できる形にすることです。
+
+結果として、実装後に大きな差分を戻す回数を減らし、チームとしてレビューしやすい状態を作ることを狙っています。
+
+### 小さな個人開発でも使う意味はありますか？
+
+あります。ただし、最初から全機能を入れる必要はありません。
+
+まずは「コードを書く前に計画を書かせる」「その計画にNon-goalsとTest planを含める」だけでも十分です。
+
+### River Reviewerとはどう使い分けますか？
+
+PlanGateは主に実装前の承認とスコープ固定に向いています。
+
+River Reviewerは、要件、設計、実装、テスト、運用という開発の流れ全体をレビューするための仕組みです。実装前をPlanGateで止め、レビュー観点をRiver Reviewerで育てる、という役割分担で考えています。
+
+## 関連記事
+
+- [AIコードレビューはPRだけ見ていていいのか？ 開発の流れ全体をレビューするOSS「River Reviewer」を作った](https://qiita.com/s977043/items/5a4665e78c4bd1a5c1bc)
+- [アジャイルでAI駆動開発をどう回すか: PlanGateの考え方とテンプレート](https://zenn.dev/minewo/articles/plangate-ai-coding-workflow)
+- [AI駆動開発の2層ガード設計：PlanGateとRiver Reviewerで実装前後を守る](https://zenn.dev/minewo/articles/ai-dev-guardrail-plangate-river-reviewer)

--- a/Qiita/public/river-reviewer-flow-based-ai-review.md
+++ b/Qiita/public/river-reviewer-flow-based-ai-review.md
@@ -7,7 +7,7 @@ tags:
   - コードレビュー
   - GitHubActions
 private: false
-updated_at: '2026-05-11T15:28:53+09:00'
+updated_at: '2026-05-11T16:35:14+09:00'
 id: 5a4665e78c4bd1a5c1bc
 organization_url_name: null
 slide: false
@@ -383,6 +383,32 @@ AIで実装速度が上がるほど、レビューはボトルネックになり
 
 River Reviewer は、そのボトルネックを単に自動化するのではなく、レビューをチームの知識資産に変えることを目指しています。
 
-GitHub で公開しているので、興味があればぜひ見てみてください。
+## FAQ
 
-https://github.com/s977043/river-reviewer
+### River Reviewerは既存のAIコードレビューと何が違いますか？
+
+既存のAIコードレビューは、PR差分に対する指摘が中心になりやすいです。
+
+River Reviewerは、PR差分だけでなく、要件、設計、実装、テスト、運用までを開発の流れとして扱うことを重視しています。
+
+### 最初からUpstream、Midstream、Downstreamを全部入れる必要がありますか？
+
+ありません。
+
+最初は、テスト不足チェックやAPI変更チェックのように、効果が見えやすい観点から小さく始めるのがよいです。
+
+### PlanGateとはどう組み合わせますか？
+
+PlanGateは、AIが実装を始める前に計画を作り、人間が承認するための仕組みです。
+
+River Reviewerは、その前後を含めてレビュー観点をSkillとして育てる仕組みです。PlanGateで実装前に止め、River Reviewerでレビュー観点を継続的に改善する、という組み合わせを想定しています。
+
+## 参考リンク
+
+- [River Reviewer GitHub Repository](https://github.com/s977043/river-reviewer)
+
+## 関連記事
+
+- [AIコーディングエージェントをチームで使うために、PlanGateで「承認してから実装」を始めた](https://qiita.com/s977043/items/93027e02e962ec327c2f)
+- [AIエージェントを"投げっぱなし"にしない：Agent Skillsと自由度の設計で実現する「評価駆動の開発エコシステム」](https://zenn.dev/minewo/articles/zenn-river-reviewer-architecture)
+- [AI駆動開発の2層ガード設計：PlanGateとRiver Reviewerで実装前後を守る](https://zenn.dev/minewo/articles/ai-dev-guardrail-plangate-river-reviewer)


### PR DESCRIPTION
## Summary\n- Add FAQ sections to the published PlanGate and River Reviewer Qiita articles\n- Add cross-domain related links at the end of each Qiita article\n- Publish the updated articles to Qiita and reflect updated_at metadata\n\n## Updated Qiita articles\n- https://qiita.com/s977043/items/93027e02e962ec327c2f\n- https://qiita.com/s977043/items/5a4665e78c4bd1a5c1bc\n\n## Verification\n- npm run check\n- npm run publish:qiita -- 93027e02e962ec327c2f\n- npm run publish:qiita -- river-reviewer-flow-based-ai-review