### PR TITLE
docs(article): publish multi-AI discussion roadmap rewrite (Zenn)

### DIFF
--- a/articles/multi-ai-discussion-roadmap-rewrite.md
+++ b/articles/multi-ai-discussion-roadmap-rewrite.md
@@ -3,7 +3,7 @@ title: "AIエージェント3種で戦略議論したら、OSSロードマップ
 emoji: "🗣️"
 type: "tech"
 topics: ["ai", "claudecode", "codex", "gemini", "oss"]
-published: false
+published: true
 ---
 
 私は PlanGate という、AI コーディングエージェント向けの軽量ガバナンスハーネスを個人 OSS として開発しています。


### PR DESCRIPTION
## 概要

`articles/multi-ai-discussion-roadmap-rewrite.md` を `published: false → true` に切替。

これは **main への PR で Zenn deploy は発火しません**（deploy 対象は `release/zenn` ブランチのみ）。本 PR マージ後、別途 `release/zenn` 同期 PR で公開が発火します。

## 経緯

- 記事本体は PR #237 でマージ済み（3ペルソナ + Codex 二次レビュー反映済み）
- `npm run check:zenn-pace`: 過去24h 切替 0 件 → rate-limit 安全圏

## チェック

- [x] `npm run check` パス
- [x] zenn-pace 安全圏（0/24h）
- [x] 差分は published フラグ 1 行のみ

🤖 後続: release/zenn 公開 PR で deploy 発火