### PR TITLE
feat(publish): weekly scheduled publish (Qiita/Zenn, notify→approve→publish)

### DIFF
--- a/.github/workflows/weekly-publish-notify.yml
+++ b/.github/workflows/weekly-publish-notify.yml
@@ -1,0 +1,45 @@
+name: Weekly Publish Notify
+
+# 前日（木 18:00 JST = 木 09:00 UTC）に、次の公開対象を承認 Issue として起票する。
+# 公開はしない。内容確認と承認の起点。
+
+on:
+  schedule:
+    - cron: '0 9 * * 4' # Thu 09:00 UTC = Thu 18:00 JST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TZ: Asia/Tokyo
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - name: Build notify body
+        id: body
+        run: |
+          node scripts/weekly-publish.mjs notify > /tmp/notify.md
+          echo "has_target=$(grep -q 'QUEUE_EMPTY\|QUEUE_SKIP' /tmp/notify.md && echo false || echo true)" >> "$GITHUB_OUTPUT"
+          cat /tmp/notify.md
+      - name: Open approval issue
+        if: steps.body.outputs.has_target == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="週次公開 承認リクエスト $(date +%Y-%m-%d)（金 18:00 JST 予定）"
+          gh issue create --title "$title" --body-file /tmp/notify.md --label weekly-publish
+      - name: Notify queue empty/skip
+        if: steps.body.outputs.has_target == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --title "週次公開: 今週は対象なし $(date +%Y-%m-%d)" --body-file /tmp/notify.md --label weekly-publish

--- a/.github/workflows/weekly-publish.yml
+++ b/.github/workflows/weekly-publish.yml
@@ -1,0 +1,85 @@
+name: Weekly Publish
+
+# 金 18:00 JST（= 金 09:00 UTC）に公開。
+# environment: production-publish の Required reviewers 承認を通過するまで publish ステップは実行されない。
+# 初回は workflow_dispatch + dry_run=true で必ずドライラン。
+
+on:
+  schedule:
+    - cron: '0 9 * * 5' # Fri 09:00 UTC = Fri 18:00 JST
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'ドライラン（公開せず差分のみ表示）'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # 承認ゲート: この Environment に Required reviewers を設定しておくこと（docs/weekly-publish-schedule.md）
+    environment: production-publish
+    env:
+      TZ: Asia/Tokyo
+      QIITA_TOKEN: ${{ secrets.QIITA_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+
+      - name: Resolve mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "false" ]; then
+            echo "execute=--execute" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "execute=--execute" >> "$GITHUB_OUTPUT"
+          else
+            echo "execute=" >> "$GITHUB_OUTPUT"   # dispatch + dry_run(default true) → dry-run
+          fi
+
+      - name: Pre-flight (zenn pace)
+        run: npm run --silent check:zenn-pace || echo "zenn-pace WARN/FAIL — script 側で再判定"
+
+      - name: Run weekly publish
+        id: pub
+        run: node scripts/weekly-publish.mjs publish ${{ steps.mode.outputs.execute }}
+
+      - name: Commit queue advance & frontmatter (execute only)
+        if: steps.mode.outputs.execute == '--execute'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "no changes to commit"
+          else
+            git add docs/publish-queue.md Qiita/ articles/
+            git commit -m "chore(publish): weekly publish $(date +%Y-%m-%d) [skip ci]"
+            git push origin HEAD:main
+          fi
+
+      - name: Open release/zenn PR if Zenn published_at changed
+        if: steps.mode.outputs.execute == '--execute'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Zenn は release/zenn マージで deploy。published_at 設定済み記事があれば PR を作る（マージは人手＝最終ゲート）
+          if git log -1 --name-only --pretty=format: | grep -q '^articles/'; then
+            br="release/zenn-weekly-$(date +%Y%m%d)"
+            git switch -c "$br"
+            git push -u origin "$br" || true
+            gh pr create --base release/zenn --head "$br" \
+              --title "chore(release/zenn): weekly publish $(date +%Y-%m-%d)" \
+              --body "週次公開（Zenn）。published_at 設定済み。rate-limit を確認しマージで予約公開発火。" || true
+          else
+            echo "Zenn 対象なし（今週は Qiita のみ等）"
+          fi

--- a/.github/workflows/weekly-publish.yml
+++ b/.github/workflows/weekly-publish.yml
@@ -22,6 +22,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # キルスイッチ: repo variable WEEKLY_PUBLISH_ENABLED == 'true' でのみ起動。
+    # 既定 OFF。Secret/Environment セットアップ完了後にユーザーが明示的に有効化する。
+    # （Environment 未作成のまま cron が保護なしで走る事故を防ぐ二重安全弁）
+    if: vars.WEEKLY_PUBLISH_ENABLED == 'true'
     # 承認ゲート: この Environment に Required reviewers を設定しておくこと（docs/weekly-publish-schedule.md）
     environment: production-publish
     env:

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -1,0 +1,33 @@
+# Publish Queue（週次公開キュー）
+
+週次公開スケジューラ（[`weekly-publish-schedule.md`](./weekly-publish-schedule.md)）が参照するキュー。**`## Queue` の先頭が次に公開する1本**。月次振り返りで Rolling roadmap（[`content-channel-strategy.md`](./content-channel-strategy.md)）から補充する。
+
+## エントリ形式
+
+```
+- platform: <qiita|zenn>
+  basename: <ファイル名（拡張子なし）>
+  path: <リポジトリ内パス>
+  review_class: <Full|Standard|Light>
+  goal_dod: <誰の・どの課題を解決し、読者は何ができるか 1行>
+```
+
+`- [SKIP] <理由>` を先頭に置くとその週はスキップ（publish ジョブが消化）。
+
+## Queue
+
+- platform: qiita
+  basename: claude-code-scope-creep-countermeasure
+  path: Qiita/public/claude-code-scope-creep-countermeasure.md
+  review_class: Full
+  goal_dod: Claude Code 利用者の「AIが実装範囲を勝手に広げる」課題を解決し、読者は実装前の境界設定を実践できる
+
+- platform: qiita
+  basename: ai-coding-preflight-checklist
+  path: Qiita/public/ai-coding-preflight-checklist.md
+  review_class: Full
+  goal_dod: AIコーディング実務者の「計画が曖昧で実装後レビューが重い」課題を解決し、読者は5項目チェックを実践できる
+
+## Done
+
+（公開済みエントリを公開日とともにここへ移動）

--- a/docs/weekly-publish-schedule.md
+++ b/docs/weekly-publish-schedule.md
@@ -1,0 +1,57 @@
+# 週次公開スケジュール運用
+
+毎週1記事を Qiita / Zenn に公開する運用。**前日通知 → 承認 → 公開**のゲート付き。Rolling roadmap と連動。
+
+- 由来: ユーザー要望（毎週公開のスケジュール化, 2026-05-17）
+- 関連: [`content-channel-strategy.md`](./content-channel-strategy.md)（Rolling roadmap）/ [`post-publish-review-cycle.md`](./post-publish-review-cycle.md) / [`review-gate-tiers.md`](./review-gate-tiers.md)
+
+## 確定仕様
+
+| 項目 | 値 |
+|---|---|
+| 対象媒体 | Qiita / Zenn（note は手動インポート必須のため対象外） |
+| 公開日時 | 毎週 **金曜 18:00 JST**（= 金 09:00 UTC） |
+| 通知 | **前日 木曜 18:00 JST**（= 木 09:00 UTC）に承認 Issue を自動起票 |
+| 承認 | GitHub Environment `production-publish` の required reviewer 承認（人が承認するまで公開ジョブは走らない） |
+| 記事選定 | **Rolling roadmap 連動**。次に出す記事は [`publish-queue.md`](./publish-queue.md) の先頭から（キューは月次振り返りで Rolling roadmap から補充） |
+| 自動度 | 前日通知 → 人が承認 → 翌日公開（完全自動公開はしない＝取り消し困難な外部アクションの安全弁） |
+
+## 週次フロー
+
+```
+木 09:00 UTC  notify ジョブ
+  └─ publish-queue.md 先頭エントリを読む
+  └─ 承認 Issue 起票（媒体/記事/レビュークラス/Goal-DoD/rate-limit 状況を記載）
+        ↓ 人間が内容確認・必要なら記事修正
+  └─ 承認: Issue を閉じる前に Environment 承認待ちジョブを approve（または publish を中止＝queueをskip操作）
+金 09:00 UTC  publish ジョブ（Environment 承認ゲート通過後のみ実行）
+  └─ rate-limit 事前チェック（npm run check:zenn-pace。FAIL なら中止）
+  └─ Qiita: ignorePublish→false / updated_at更新 / 公開当日HTMLコメント削除 / qiita publish
+  └─ Zenn: published_at を金18:00に設定 / release/zenn へ反映（24h/3本ルール厳守）
+  └─ publish-queue.md の先頭を done セクションへ移動（キュー前進）
+  └─ 公開後レビュー予定（T+30/T+180）を post-publish-review-cycle に沿って起票
+```
+
+## Rate-limit との関係
+
+- 1 週 1 記事のため Zenn 24h/5本・1PR3本ルールには通常抵触しない
+- ただし手動公開と重なる週は `npm run check:zenn-pace` が WARN/FAIL を返しうる。publish ジョブは事前チェックで FAIL なら**公開せずキューを翌週送り**にする
+- Qiita はネイティブ予約なし。本運用の cron が実質の予約機構
+
+## 必要なユーザー側セットアップ（1回のみ・Claude では実行不可）
+
+1. **Secret `QIITA_TOKEN`** をリポジトリに追加（Qiita CLI 認証。Qiita > 設定 > アプリケーション > 個人用アクセストークン）
+2. **GitHub Environment `production-publish`** を作成し **Required reviewers** に自分を設定（承認ゲート）
+3. 初回サイクルは `workflow_dispatch` の `dry_run: true` で**ドライラン**し、想定どおり通知/差分が出ることを確認してから本番運用へ
+
+## キュー運用
+
+- [`publish-queue.md`](./publish-queue.md) の `## Queue` 先頭が「次に公開する1本」
+- 月次振り返り（post-publish-review-cycle）で Rolling roadmap から翌月分を補充
+- 各エントリは媒体・basename・レビュークラス・Goal-DoD を明記（review-gate-tiers の DoD を満たすこと）
+- 公開済みは `## Done` へ移動（履歴）
+
+## 中止・スキップ
+
+- 承認 Issue で承認しない（Environment approve しない）→ その週は公開されずキュー据え置き
+- 特定週を飛ばす: `publish-queue.md` 先頭に `- [SKIP] <理由>` を置く（publish ジョブは SKIP を消化して次回へ）

--- a/docs/weekly-publish-schedule.md
+++ b/docs/weekly-publish-schedule.md
@@ -42,7 +42,8 @@
 
 1. **Secret `QIITA_TOKEN`** をリポジトリに追加（Qiita CLI 認証。Qiita > 設定 > アプリケーション > 個人用アクセストークン）
 2. **GitHub Environment `production-publish`** を作成し **Required reviewers** に自分を設定（承認ゲート）
-3. 初回サイクルは `workflow_dispatch` の `dry_run: true` で**ドライラン**し、想定どおり通知/差分が出ることを確認してから本番運用へ
+3. 初回サイクルは `workflow_dispatch` の `dry_run: true` で**ドライラン**し、想定どおり通知/差分が出ることを確認
+4. 上記 1〜3 完了後、**repo variable `WEEKLY_PUBLISH_ENABLED` を `true`** に設定（キルスイッチ）。これを設定するまで publish ジョブは cron でも一切起動しない（Environment 未作成のまま走る事故の二重安全弁）。停止したいときは `false` に戻すだけ
 
 ## キュー運用
 

--- a/scripts/weekly-publish.mjs
+++ b/scripts/weekly-publish.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// 週次公開スケジューラのコアロジック。
+// 仕様: docs/weekly-publish-schedule.md / キュー: docs/publish-queue.md
+//
+// 使い方:
+//   node scripts/weekly-publish.mjs notify              # 次エントリの通知用サマリを stdout に出す
+//   node scripts/weekly-publish.mjs publish [--dry-run]  # 次エントリを公開（--dry-run 既定 OFF だが CI は明示渡し推奨）
+//
+// 設計方針:
+//   - 取り消し困難な外部公開のため、publish は --execute を明示しない限り dry-run
+//   - Qiita = qiita CLI（要 QIITA_TOKEN）。Zenn = published_at 設定 + release/zenn 反映は人手/承認ゲート前提
+//   - rate-limit: publish 前に npm run check:zenn-pace を実行し FAIL なら中止
+//   - キュー前進は publish 成功時のみ
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const QUEUE = path.join(REPO, 'docs/publish-queue.md');
+
+function fail(msg) {
+  console.error(`[weekly-publish] ERROR: ${msg}`);
+  process.exit(1);
+}
+
+/** publish-queue.md の ## Queue 先頭エントリを構造化して返す */
+function parseQueue() {
+  if (!existsSync(QUEUE)) fail('docs/publish-queue.md が見つからない');
+  const text = readFileSync(QUEUE, 'utf8');
+  // 見出しは行頭アンカーで判定（本文中の `## Queue` 言及を誤検出しない）
+  const qm = text.match(/^## Queue\s*$/m);
+  const dm = text.match(/^## Done\s*$/m);
+  if (!qm || !dm) fail('publish-queue.md の ## Queue / ## Done 見出しが不正');
+  const qStart = qm.index + qm[0].length;
+  const qEnd = dm.index;
+  if (qEnd <= qStart) fail('publish-queue.md のセクション順序が不正');
+  const body = text.slice(qStart, qEnd);
+
+  const skip = body.match(/^- \[SKIP\]\s*(.*)$/m);
+  if (skip) return { kind: 'skip', reason: skip[1].trim(), raw: text };
+
+  // 最初の "- platform:" ブロックを拾う
+  const m = body.match(/- platform:\s*(\S+)[\s\S]*?basename:\s*(\S+)[\s\S]*?path:\s*(\S+)[\s\S]*?review_class:\s*(\S+)[\s\S]*?goal_dod:\s*(.+)/);
+  if (!m) return { kind: 'empty', raw: text };
+  return {
+    kind: 'entry',
+    platform: m[1].trim(),
+    basename: m[2].trim(),
+    path: m[3].trim(),
+    review_class: m[4].trim(),
+    goal_dod: m[5].trim(),
+    raw: text,
+  };
+}
+
+function zennPaceOk() {
+  try {
+    execSync('npm run --silent check:zenn-pace', { cwd: REPO, stdio: 'pipe' });
+    return true;
+  } catch (e) {
+    const out = (e.stdout?.toString() || '') + (e.stderr?.toString() || '');
+    return !/FAIL/.test(out);
+  }
+}
+
+function cmdNotify() {
+  const q = parseQueue();
+  if (q.kind === 'empty') {
+    console.log('QUEUE_EMPTY: 公開キューが空です。Rolling roadmap から補充してください。');
+    return;
+  }
+  if (q.kind === 'skip') {
+    console.log(`QUEUE_SKIP: 今週はスキップ指定 — ${q.reason}`);
+    return;
+  }
+  const pace = zennPaceOk() ? 'OK' : 'WARN/FAIL（公開時に再判定・FAILなら翌週送り）';
+  console.log(
+    [
+      '## 週次公開 承認リクエスト（金 18:00 JST 予定）',
+      '',
+      `- 媒体: **${q.platform}**`,
+      `- 記事: \`${q.path}\``,
+      `- レビュークラス: ${q.review_class}`,
+      `- Goal-DoD: ${q.goal_dod}`,
+      `- zenn-pace 事前: ${pace}`,
+      '',
+      '### 承認手順',
+      '1. 記事内容を最終確認（必要なら修正コミット）',
+      '2. Actions の `weekly-publish` 実行を Environment `production-publish` で **Approve**',
+      '3. 中止する場合は Approve しない（キュー据え置き）。特定週スキップは publish-queue.md 先頭に `- [SKIP] 理由`',
+    ].join('\n'),
+  );
+}
+
+function publishQiita(entry, execute) {
+  const abs = path.join(REPO, entry.path);
+  if (!existsSync(abs)) fail(`記事が見つからない: ${entry.path}`);
+  let md = readFileSync(abs, 'utf8');
+
+  const now = new Date().toISOString().replace(/\.\d+Z$/, '+09:00'); // 簡易（CIはTZ=Asia/Tokyo前提）
+  const before = md;
+  md = md.replace(/^ignorePublish:\s*true\s*$/m, 'ignorePublish: false');
+  md = md.replace(/^updated_at:\s*.*$/m, `updated_at: '${now}'`);
+  // 公開当日チェックリストの HTML コメントブロックを削除
+  md = md.replace(/<!--\s*\n公開当日チェックリスト[\s\S]*?-->\n?/m, '');
+
+  if (before === md) {
+    console.log('[qiita] frontmatter に変更なし（既に公開設定の可能性）。続行。');
+  }
+  if (!execute) {
+    console.log(`[qiita][dry-run] ${entry.basename}: ignorePublish→false / updated_at 更新 / 当日コメント削除 を適用予定`);
+    console.log('[qiita][dry-run] npx qiita publish をスキップ');
+    return;
+  }
+  writeFileSync(abs, md);
+  if (!process.env.QIITA_TOKEN) fail('QIITA_TOKEN secret 未設定。リポジトリ Secrets に追加が必要');
+  execSync(`npx qiita publish ${entry.basename} --root Qiita`, { cwd: REPO, stdio: 'inherit' });
+  console.log(`[qiita] 公開実行: ${entry.basename}`);
+}
+
+function publishZenn(entry, execute) {
+  const abs = path.join(REPO, entry.path);
+  if (!existsSync(abs)) fail(`記事が見つからない: ${entry.path}`);
+  let md = readFileSync(abs, 'utf8');
+  // 金曜 18:00 JST を published_at に設定（予約公開）
+  const d = new Date();
+  const fri = new Date(d);
+  fri.setUTCHours(9, 0, 0, 0); // 09:00 UTC = 18:00 JST
+  const stamp = `${fri.getUTCFullYear()}-${String(fri.getUTCMonth() + 1).padStart(2, '0')}-${String(fri.getUTCDate()).padStart(2, '0')} 18:00`;
+  if (/^published_at:/m.test(md)) md = md.replace(/^published_at:.*$/m, `published_at: "${stamp}"`);
+  else md = md.replace(/^published:\s*true\s*$/m, `published: true\npublished_at: "${stamp}"`);
+
+  if (!zennPaceOk()) {
+    console.log('[zenn] check:zenn-pace FAIL → 今週は公開せずキュー据え置き（rate-limit 安全弁）');
+    process.exit(2);
+  }
+  if (!execute) {
+    console.log(`[zenn][dry-run] ${entry.basename}: published_at="${stamp}" を設定予定 / release/zenn 反映は承認後の別手順`);
+    return;
+  }
+  writeFileSync(abs, md);
+  console.log(`[zenn] published_at=${stamp} 設定。release/zenn への反映は workflow の承認後ステップで実施`);
+}
+
+function advanceQueue(entry) {
+  const text = readFileSync(QUEUE, 'utf8');
+  const block = new RegExp(
+    `- platform:\\s*${entry.platform}[\\s\\S]*?goal_dod:\\s*${entry.goal_dod.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n?`,
+  );
+  const removed = text.replace(block, '');
+  const today = new Date().toISOString().slice(0, 10);
+  const doneLine = `- ${today} ${entry.platform} ${entry.basename}\n`;
+  const out = removed.replace(/## Done\n/, `## Done\n${doneLine}`);
+  writeFileSync(QUEUE, out);
+  console.log(`[queue] ${entry.basename} を Done へ移動`);
+}
+
+function cmdPublish(execute) {
+  const q = parseQueue();
+  if (q.kind === 'empty') {
+    console.log('QUEUE_EMPTY: 公開対象なし。終了。');
+    return;
+  }
+  if (q.kind === 'skip') {
+    // SKIP 行を消費して終了（次回は次エントリ）
+    const text = readFileSync(QUEUE, 'utf8').replace(/^- \[SKIP\].*\n?/m, '');
+    writeFileSync(QUEUE, text);
+    console.log(`QUEUE_SKIP 消費: ${q.reason}`);
+    return;
+  }
+  if (q.platform === 'qiita') publishQiita(q, execute);
+  else if (q.platform === 'zenn') publishZenn(q, execute);
+  else fail(`未知の platform: ${q.platform}`);
+
+  if (execute) advanceQueue(q);
+  else console.log('[dry-run] キュー前進はスキップ（--execute 時のみ）');
+}
+
+const mode = process.argv[2];
+const execute = process.argv.includes('--execute');
+if (mode === 'notify') cmdNotify();
+else if (mode === 'publish') cmdPublish(execute);
+else fail('mode は notify | publish');


### PR DESCRIPTION
## Summary
毎週1記事を Qiita/Zenn に公開する仕組み。確定仕様（ヒアリング済）:
- 対象: **Qiita + Zenn**（note は手動インポートのため対象外）
- 日時: **毎週金 18:00 JST**
- 自動度: **前日(木18:00)通知 → 承認 → 翌日公開**（完全自動公開はしない安全弁）
- 記事選定: **Rolling roadmap 連動**（`docs/publish-queue.md` 先頭）

## 構成
| ファイル | 役割 |
|---|---|
| `docs/weekly-publish-schedule.md` | 運用仕様・フロー・rate-limit関係・必要セットアップ |
| `docs/publish-queue.md` | 週次キュー（先頭=次の1本、月次振り返りでRollingから補充） |
| `scripts/weekly-publish.mjs` | notify/publishロジック（dry-run既定・zenn-pace安全弁・キュー前進） |
| `.github/workflows/weekly-publish-notify.yml` | 木09:00UTC 承認Issue起票（公開しない） |
| `.github/workflows/weekly-publish.yml` | 金09:00UTC 公開（environment承認ゲート） |

## 安全設計
- publish は environment `production-publish` の Required reviewers 承認を通過するまで実行されない
- `workflow_dispatch` は **dry_run=true 既定**（初回は必ずドライラン）
- 公開前に `check:zenn-pace`、FAIL ならその週は公開せずキュー据え置き
- Qiita=CLI公開、Zenn=published_at設定+release/zenn PR作成（マージは人手＝最終ゲート、既存Zennフロー踏襲）

## ⚠️ 要ユーザーセットアップ（Claude では実行不可・マージ後）
1. リポジトリ Secret **`QIITA_TOKEN`** 追加（Qiita 個人用アクセストークン）
2. GitHub Environment **`production-publish`** を作成し Required reviewers に自分を設定
3. 初回は Actions → Weekly Publish → Run workflow（**dry_run=true**）で検証

## Test plan
- [x] `node -c scripts/weekly-publish.mjs`（構文）
- [x] `weekly-publish.mjs notify` / `publish`（dry-run）でキュー先頭を正しく解決、queue 非破壊を確認
- [x] 本文中の `## Queue` 誤検出バグを行頭アンカーで修正
- [x] 両 workflow YAML 妥当性 / `.nvmrc` 参照整合
- [x] `npm run check` パス（note-tables WARN は既存 articles_note 対象で本PR無関係）

## 関連
- Rolling roadmap: `content-channel-strategy.md` / 公開後: `post-publish-review-cycle.md` / レビュー: `review-gate-tiers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)