### PR TITLE
docs(qiita): add PlanGate metrics diagrams

### DIFF
--- a/Qiita/public/5ebff79112ecf1af872c.md
+++ b/Qiita/public/5ebff79112ecf1af872c.md
@@ -49,6 +49,8 @@ v8.6.0 でやったことを一言でまとめると、こうです。
 
 順番が大事で、4 番目（Metrics 実装）の前に 1〜3（baseline / governance / privacy）を確定させています。これがないと、Metricsを取り始めても「比較対象がない」「保存可否を都度判断」「推測データが混ざる」で、せっかく取った数字が信頼できなくなります。
 
+![PlanGate v8.6.0 で baseline、Issue governance、Metrics privacy、Metrics v1 の順に整える理由](https://raw.githubusercontent.com/s977043/my-blog/main/Qiita/public/plangate-v86-metrics-governance-order-ja.svg)
+
 この記事は、PlanGate を v8.5.0 まで触ってきた人、または「AI のレビュー疲れを数字で改善したい」と感じている人向けです。
 
 ## 以前の使い方で困ったこと
@@ -161,6 +163,8 @@ bin/plangate metrics --aggregate --json
 ```
 
 「気がする」ではなく、**TASK と回数で会話できる**ようになったのが大きな変化でした。
+
+![PlanGate Metrics v1 で Hook 違反をイベント化し、集計して改善へ戻す流れ](https://raw.githubusercontent.com/s977043/my-blog/main/Qiita/public/plangate-v86-metrics-feedback-loop-ja.svg)
 
 ## 「推測で埋めない」というルール
 

--- a/Qiita/public/plangate-v86-metrics-feedback-loop-ja.svg
+++ b/Qiita/public/plangate-v86-metrics-feedback-loop-ja.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">PlanGate Metrics v1 の改善ループ</title>
+  <desc id="desc">Hook違反などのイベントを集計し、retrospectiveで改善アクションへつなげる流れ</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.13"/>
+    </filter>
+    <marker id="arrow" markerWidth="14" markerHeight="14" refX="10" refY="7" orient="auto">
+      <path d="M0,0 L14,7 L0,14 z" fill="#0f8f88"/>
+    </marker>
+  </defs>
+  <rect width="1600" height="900" fill="#fbfcfd"/>
+  <text x="800" y="78" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif" font-size="48" font-weight="800" fill="#142033">「止まった」を記録して、次の改善に戻す</text>
+  <text x="800" y="126" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif" font-size="24" fill="#475569">Metrics v1 はダッシュボード目的ではなく、改善判断の材料として置く</text>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif" filter="url(#shadow)">
+    <rect x="85" y="235" width="290" height="210" rx="26" fill="#eff6ff" stroke="#2563eb" stroke-width="3"/>
+    <text x="230" y="292" text-anchor="middle" font-size="32" font-weight="800" fill="#172033">Hookが止める</text>
+    <text x="230" y="342" text-anchor="middle" font-size="23" fill="#334155">例: forbidden_files</text>
+    <text x="230" y="376" text-anchor="middle" font-size="23" fill="#334155">plan_hash</text>
+    <text x="230" y="410" text-anchor="middle" font-size="23" fill="#334155">merge_approval</text>
+
+    <rect x="460" y="235" width="290" height="210" rx="26" fill="#eefdfb" stroke="#0f8f88" stroke-width="3"/>
+    <text x="605" y="292" text-anchor="middle" font-size="32" font-weight="800" fill="#172033">Event化する</text>
+    <text x="605" y="342" text-anchor="middle" font-size="23" fill="#334155">TASK ID</text>
+    <text x="605" y="376" text-anchor="middle" font-size="23" fill="#334155">hook名</text>
+    <text x="605" y="410" text-anchor="middle" font-size="23" fill="#334155">decision / result</text>
+
+    <rect x="835" y="235" width="290" height="210" rx="26" fill="#fff7ed" stroke="#ea580c" stroke-width="3"/>
+    <text x="980" y="292" text-anchor="middle" font-size="32" font-weight="800" fill="#172033">集計する</text>
+    <text x="980" y="342" text-anchor="middle" font-size="23" fill="#334155">TASK別</text>
+    <text x="980" y="376" text-anchor="middle" font-size="23" fill="#334155">Hook別</text>
+    <text x="980" y="410" text-anchor="middle" font-size="23" fill="#334155">週次推移</text>
+
+    <rect x="1210" y="235" width="290" height="210" rx="26" fill="#f1f5f9" stroke="#475569" stroke-width="3"/>
+    <text x="1355" y="292" text-anchor="middle" font-size="32" font-weight="800" fill="#172033">改善に戻す</text>
+    <text x="1355" y="342" text-anchor="middle" font-size="23" fill="#334155">allowed_files見直し</text>
+    <text x="1355" y="376" text-anchor="middle" font-size="23" fill="#334155">scope分割</text>
+    <text x="1355" y="410" text-anchor="middle" font-size="23" fill="#334155">Hook strict化</text>
+  </g>
+
+  <path d="M380 340 H445" stroke="#0f8f88" stroke-width="8" marker-end="url(#arrow)"/>
+  <path d="M755 340 H820" stroke="#0f8f88" stroke-width="8" marker-end="url(#arrow)"/>
+  <path d="M1130 340 H1195" stroke="#0f8f88" stroke-width="8" marker-end="url(#arrow)"/>
+  <path d="M1355 450 C1360 645, 260 645, 230 455" fill="none" stroke="#0f8f88" stroke-width="8" stroke-dasharray="18 16" marker-end="url(#arrow)"/>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif">
+    <rect x="190" y="585" width="1220" height="165" rx="30" fill="#ffffff" stroke="#cbd5e1" stroke-width="3"/>
+    <text x="800" y="634" text-anchor="middle" font-size="30" font-weight="800" fill="#172033">Retrospective での会話が変わる</text>
+    <text x="800" y="684" text-anchor="middle" font-size="25" fill="#334155">「最近止まっている気がする」</text>
+    <text x="800" y="726" text-anchor="middle" font-size="25" font-weight="800" fill="#0f8f88">「hook_violation 12件。うち forbidden_files 8件、5件は TASK-0078 系」</text>
+  </g>
+</svg>

--- a/Qiita/public/plangate-v86-metrics-governance-order-ja.svg
+++ b/Qiita/public/plangate-v86-metrics-governance-order-ja.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">PlanGate v8.6.0 の導入順</title>
+  <desc id="desc">baseline、Issue governance、Metrics privacy、Metrics v1 の順に整えることを示す図</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.13"/>
+    </filter>
+    <marker id="arrow" markerWidth="14" markerHeight="14" refX="10" refY="7" orient="auto">
+      <path d="M0,0 L14,7 L0,14 z" fill="#64748b"/>
+    </marker>
+  </defs>
+  <rect width="1600" height="900" fill="#fbfcfd"/>
+  <text x="800" y="80" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif" font-size="48" font-weight="800" fill="#142033">Metrics v1 は「先に土台を固めてから」入れる</text>
+  <text x="800" y="128" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif" font-size="24" fill="#475569">比較対象・入力ルール・保存ルールがない数字は、あとから信頼しにくい</text>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif" filter="url(#shadow)">
+    <rect x="75" y="255" width="320" height="300" rx="26" fill="#eff6ff" stroke="#2563eb" stroke-width="3"/>
+    <circle cx="130" cy="310" r="32" fill="#2563eb"/>
+    <text x="130" y="322" text-anchor="middle" font-size="32" font-weight="800" fill="#fff">1</text>
+    <text x="235" y="320" text-anchor="middle" font-size="31" font-weight="800" fill="#172033">改善前 baseline</text>
+    <text x="235" y="390" text-anchor="middle" font-size="23" fill="#334155">代表TASKを固定し</text>
+    <text x="235" y="426" text-anchor="middle" font-size="23" fill="#334155">改善前の状態を</text>
+    <text x="235" y="462" text-anchor="middle" font-size="23" fill="#334155">比較可能にする</text>
+    <rect x="120" y="500" width="230" height="42" rx="14" fill="#dbeafe"/>
+    <text x="235" y="529" text-anchor="middle" font-size="20" font-weight="700" fill="#1e3a8a">「良くなった気がする」を防ぐ</text>
+
+    <rect x="455" y="255" width="320" height="300" rx="26" fill="#eefdfb" stroke="#0f8f88" stroke-width="3"/>
+    <circle cx="510" cy="310" r="32" fill="#0f8f88"/>
+    <text x="510" y="322" text-anchor="middle" font-size="32" font-weight="800" fill="#fff">2</text>
+    <text x="615" y="320" text-anchor="middle" font-size="31" font-weight="800" fill="#172033">Issue governance</text>
+    <text x="615" y="390" text-anchor="middle" font-size="23" fill="#334155">Why / What / AC を</text>
+    <text x="615" y="426" text-anchor="middle" font-size="23" fill="#334155">AIが推測で</text>
+    <text x="615" y="462" text-anchor="middle" font-size="23" fill="#334155">埋めないようにする</text>
+    <rect x="500" y="500" width="230" height="42" rx="14" fill="#ccfbf1"/>
+    <text x="615" y="529" text-anchor="middle" font-size="20" font-weight="700" fill="#115e59">推測データを混ぜない</text>
+
+    <rect x="835" y="255" width="320" height="300" rx="26" fill="#fff7ed" stroke="#ea580c" stroke-width="3"/>
+    <circle cx="890" cy="310" r="32" fill="#ea580c"/>
+    <text x="890" y="322" text-anchor="middle" font-size="32" font-weight="800" fill="#fff">3</text>
+    <text x="995" y="320" text-anchor="middle" font-size="31" font-weight="800" fill="#172033">Metrics privacy</text>
+    <text x="995" y="390" text-anchor="middle" font-size="23" fill="#334155">保存してよい情報と</text>
+    <text x="995" y="426" text-anchor="middle" font-size="23" fill="#334155">保存しない情報を</text>
+    <text x="995" y="462" text-anchor="middle" font-size="23" fill="#334155">先に線引きする</text>
+    <rect x="880" y="500" width="230" height="42" rx="14" fill="#fed7aa"/>
+    <text x="995" y="529" text-anchor="middle" font-size="20" font-weight="700" fill="#9a3412">ログ漏えいを防ぐ</text>
+
+    <rect x="1215" y="255" width="320" height="300" rx="26" fill="#f1f5f9" stroke="#475569" stroke-width="3"/>
+    <circle cx="1270" cy="310" r="32" fill="#475569"/>
+    <text x="1270" y="322" text-anchor="middle" font-size="32" font-weight="800" fill="#fff">4</text>
+    <text x="1375" y="320" text-anchor="middle" font-size="31" font-weight="800" fill="#172033">Metrics v1</text>
+    <text x="1375" y="390" text-anchor="middle" font-size="23" fill="#334155">11イベントを</text>
+    <text x="1375" y="426" text-anchor="middle" font-size="23" fill="#334155">Schemaで固定し</text>
+    <text x="1375" y="462" text-anchor="middle" font-size="23" fill="#334155">週次で集計する</text>
+    <rect x="1260" y="500" width="230" height="42" rx="14" fill="#e2e8f0"/>
+    <text x="1375" y="529" text-anchor="middle" font-size="20" font-weight="700" fill="#334155">感想を数字に変える</text>
+  </g>
+
+  <path d="M400 405 H440" stroke="#64748b" stroke-width="8" marker-end="url(#arrow)"/>
+  <path d="M780 405 H820" stroke="#64748b" stroke-width="8" marker-end="url(#arrow)"/>
+  <path d="M1160 405 H1200" stroke="#64748b" stroke-width="8" marker-end="url(#arrow)"/>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic',Meiryo,sans-serif">
+    <rect x="270" y="650" width="1060" height="110" rx="28" fill="#ffffff" stroke="#cbd5e1" stroke-width="3"/>
+    <text x="800" y="696" text-anchor="middle" font-size="28" font-weight="800" fill="#172033">順番を守る理由</text>
+    <text x="800" y="735" text-anchor="middle" font-size="23" fill="#475569">比較対象があり、推測が混ざらず、保存ルールが明確だから、Metrics の数字を改善判断に使える</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add two Japanese SVG diagrams to the PlanGate v8.6.0 Qiita article
- Insert a governance/order diagram after the four-item v8.6.0 summary
- Insert a Metrics v1 feedback-loop diagram after the TASK/count retrospective explanation

## Notes
- Image references use GitHub raw URLs, matching existing Qiita article image usage in this repository.
- The raw URLs become available from main after merge; Qiita publication still requires the normal Qiita publish/update operation.
- No frontmatter publish flags were changed.

## Validation
- npm run check
- git diff --check