### PR TITLE
chore(qiita): publish scope-creep (id assigned, queue advanced)

### DIFF
--- a/Qiita/public/claude-code-scope-creep-countermeasure.md
+++ b/Qiita/public/claude-code-scope-creep-countermeasure.md
@@ -7,25 +7,12 @@ tags:
   - チーム開発
   - コードレビュー
 private: false
-updated_at: '2026-05-13T00:00:00+09:00'
+updated_at: '2026-05-18T00:00:00+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開当日チェックリスト（来週公開予定 / 3視点+Codexレビュー反映済み 2026-05-16）:
-1. frontmatter ignorePublish: true → false に変更（これをしないと publish されない）
-2. frontmatter updated_at を公開当日の日時に更新
-3. このHTMLコメントブロックを削除（公開後も編集画面で閲覧可・社内運用語を含むため）
-4. シリーズ相互リンク確定:
-   - 「AIコーディング前に確認する5項目」(ai-coding-preflight-checklist) を同日or先行公開し本文「関連記事」に実Qiita URLを差し込む
-   - PlanGate記事リンク https://qiita.com/s977043/items/5ebff79112ecf1af872c は到達確認済み
-5. 関連リンクの実URL最終確認（PlanGate / Growth Lab は 200 確認済み 2026-05-16）
-6. npm run check パス確認 → npm run publish:qiita -- claude-code-scope-creep-countermeasure
-公開順: 本記事（症状と全体像）→ preflight（5項目の詳細）。問題提起を先に出す。
--->
 
 ## はじめに
 

--- a/Qiita/public/claude-code-scope-creep-countermeasure.md
+++ b/Qiita/public/claude-code-scope-creep-countermeasure.md
@@ -1,14 +1,14 @@
 ---
-title: 'Claude CodeでAIが勝手に実装範囲を広げる（スコープクリープ）ときの対策'
+title: Claude CodeでAIが勝手に実装範囲を広げる（スコープクリープ）ときの対策
 tags:
-  - ClaudeCode
-  - 生成AI
-  - AI駆動開発
   - チーム開発
   - コードレビュー
+  - 生成AI
+  - AI駆動開発
+  - ClaudeCode
 private: false
-updated_at: '2026-05-18T00:00:00+09:00'
-id: null
+updated_at: '2026-05-18T07:42:15+09:00'
+id: a25ec91ea411f39bf340
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -13,12 +13,11 @@
 
 | # | 締切 | platform | path | レビュー | 状態 |
 |---|---|---|---|---|---|
-| 1 | **2026-05-22（金）18:00 JST** | qiita | `Qiita/public/claude-code-scope-creep-countermeasure.md` | Full（済 PR#246） | 未公開（ignorePublish:true）|
 | 2 | **2026-05-29（金）18:00 JST** | qiita | `Qiita/public/ai-coding-preflight-checklist.md` | Full（済 PR#247） | 未公開（ignorePublish:true）|
 
-- #1 公開後、その実 Qiita URL を控え #2 公開時に「関連記事」へ差し込む（相互リンク確定は #2 公開時で可・#1 を遅らせない）
+- #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
 - 補充は手動。次テーマが決まったら行を追加（Rolling/テンプレは凍結中のため使わない）
 
 ## Done
 
-（公開済みを「YYYY-MM-DD platform basename URL」で記録）
+- 2026-05-18 qiita claude-code-scope-creep-countermeasure https://qiita.com/s977043/items/a25ec91ea411f39bf340


### PR DESCRIPTION
## Summary
Qiita 記事 **scope-creep を公開完了**（今週・締切5/22前倒し）。`npm run publish:qiita` 経由。

- 公開URL: https://qiita.com/s977043/items/a25ec91ea411f39bf340
- frontmatter: `ignorePublish:false` / `updated_at` 2026-05-18 / 採番 `id: a25ec91ea411f39bf340`（CLI書き戻し） / 公開当日HTMLコメント削除済
- `docs/publish-queue.md`: #1 を Done へ移動（URL記録）。#2 preflight は 5/29 据え置き

## dedup との独立性
`qiita publish <記事>` は `qiita pull` を伴わず、scope-creep は id:null からの新規・slug 単独のため、保留中の 93027e02 重複問題（pull 蘇生リスク）とは無関係に公開済み。**引き続き `qiita pull` は 93027e02 削除まで禁止**。

## Test plan
- [x] `npm run check` パス
- [x] Qiita CLI `Successful!` 応答確認（Posted -> a25ec91ea411f39bf340）
- [x] AGENTS.md 巻き込まず明示 staging

## 次
- #2 preflight（5/29）公開時、本文「関連記事」の scope-creep 参照へ本URLを差し込み相互リンク確定

🤖 Generated with [Claude Code](https://claude.com/claude-code)