### PR TITLE
chore(qiita): publish 3 drafts (deeplinks + id writeback + YAML fix)

### DIFF
--- a/Qiita/public/ai-coding-preflight-checklist.md
+++ b/Qiita/public/ai-coding-preflight-checklist.md
@@ -1,14 +1,14 @@
 ---
-title: AIコーディング前に確認する5項目: Goal / Scope / Non-goals / Test / Risks
+title: 'AIコーディング前に確認する5項目: Goal / Scope / Non-goals / Test / Risks'
 tags:
-  - 生成AI
-  - AI駆動開発
   - チーム開発
   - コードレビュー
+  - 生成AI
+  - AI駆動開発
   - ClaudeCode
 private: false
-updated_at: '2026-05-19T00:00:00+09:00'
-id: null
+updated_at: '2026-05-19T07:49:44+09:00'
+id: b8dacca4ce2d9079454a
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/Qiita/public/ai-coding-preflight-checklist.md
+++ b/Qiita/public/ai-coding-preflight-checklist.md
@@ -7,24 +7,12 @@ tags:
   - コードレビュー
   - ClaudeCode
 private: false
-updated_at: '2026-05-13T00:00:00+09:00'
+updated_at: '2026-05-19T00:00:00+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開当日チェックリスト（来週シリーズ公開予定 / 3視点+Codexレビュー反映済み 2026-05-16）:
-公開順: scope-creep（症状と全体像）を先、本記事（5項目詳細）を後。
-1. frontmatter ignorePublish: true → false に変更（これをしないと publish されない）
-2. frontmatter updated_at を公開当日の日時に更新
-3. このHTMLコメントブロックを削除（公開後も編集画面で閲覧可・社内運用語を含むため）
-4. 本文「関連記事」の scope-creep 参照を、scope-creep 公開後の実Qiita URLに差し込む
-   - PlanGate記事リンク https://qiita.com/s977043/items/5ebff79112ecf1af872c は到達確認済み
-5. 関連リンクの実URL最終確認（PlanGate / Growth Lab は 200 確認済み 2026-05-16）
-6. npm run check パス確認 → npm run publish:qiita -- ai-coding-preflight-checklist
--->
 
 ## はじめに
 
@@ -232,7 +220,7 @@ AIの実装速度を活かすには、実装前の確認を軽く仕組みにし
 
 この記事は「実装前に確認する5項目（Goal / Scope / Non-goals / Test / Risks）の書き方リファレンス」です。シリーズで役割を分けています。
 
-- 症状と対策の全体像（AIが勝手に実装範囲を広げる＝スコープクリープにどう気づき止めるか）: 「Claude CodeでAIが勝手に実装範囲を広げる（スコープクリープ）ときの対策」（別記事）
+- 症状と対策の全体像（AIが勝手に実装範囲を広げる＝スコープクリープにどう気づき止めるか）: [Claude CodeでAIが勝手に実装範囲を広げる（スコープクリープ）ときの対策](https://qiita.com/s977043/items/a25ec91ea411f39bf340)
 - 「止めた回数を数字で見る」運用化の実例: [AIの止まり方を「数字で見る」ようにした体験：PlanGate v8.6.0](https://qiita.com/s977043/items/5ebff79112ecf1af872c)
 
 スコープクリープ記事は「まず症状に気づいて止める」、本記事は「止めるための計画の書き方」、PlanGate記事は「止めた結果を計測する」と役割を分けています。先にスコープクリープ記事を読むと、この5項目が何を防ぐためのものか掴みやすいです。

--- a/Qiita/public/ai-dev-team-small-issues-for-agents.md
+++ b/Qiita/public/ai-dev-team-small-issues-for-agents.md
@@ -2,12 +2,12 @@
 title: AIエージェントに任せるIssueは、小さく切るほどチーム開発で扱いやすかった
 tags:
   - チーム開発
+  - プロジェクト管理
   - 生成AI
   - AI駆動開発
-  - プロジェクト管理
 private: false
-updated_at: '2026-05-19T00:00:00+09:00'
-id: null
+updated_at: '2026-05-19T07:49:52+09:00'
+id: b13950837889d97479fc
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/Qiita/public/ai-dev-team-small-issues-for-agents.md
+++ b/Qiita/public/ai-dev-team-small-issues-for-agents.md
@@ -6,19 +6,12 @@ tags:
   - AI駆動開発
   - プロジェクト管理
 private: false
-updated_at: '2026-04-29T00:00:00+09:00'
+updated_at: '2026-05-19T00:00:00+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-作業メモ:
-- 新規Qiita下書き。公開前に title / tags / private / ignorePublish を最終確認する。
-- 公開する場合は ignorePublish: false に変更する。
-- 既存のAIチーム開発シリーズに合わせ、体験談と運用改善を中心にした構成。
--->
 
 ## はじめに
 

--- a/Qiita/public/river-reviewer-agent-skills.md
+++ b/Qiita/public/river-reviewer-agent-skills.md
@@ -1,14 +1,14 @@
 ---
 title: プロンプトを磨くのをやめた：チームのレビュー知識を Agent Skills に変える River Reviewer 体験
 tags:
-  - 生成AI
-  - AI駆動開発
+  - OSS
   - コードレビュー
   - GitHubActions
-  - OSS
+  - 生成AI
+  - AI駆動開発
 private: false
-updated_at: '2026-05-19T00:00:00+09:00'
-id: null
+updated_at: '2026-05-19T07:49:58+09:00'
+id: 607d78c35745b17f9bc8
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/Qiita/public/river-reviewer-agent-skills.md
+++ b/Qiita/public/river-reviewer-agent-skills.md
@@ -6,21 +6,13 @@ tags:
   - コードレビュー
   - GitHubActions
   - OSS
-private: true
-updated_at: '2026-05-07T07:00:00+09:00'
+private: false
+updated_at: '2026-05-19T00:00:00+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開メモ:
-- 初期状態はローカル下書き: ignorePublish: true
-- Qiita へ限定共有する場合: private: true / ignorePublish: false
-- 一般公開する場合: private: false / ignorePublish: false
-- Codex review 完了後に公開判断する想定
--->
 
 ## はじめに
 


### PR DESCRIPTION
## 概要
Codex相談の合意方針で、未公開Qiita原稿3本を公開。自社メディア `the3396.com/articles` への深リンク導線つき（リファラル流入目的）。

## 公開結果
| 記事 | Qiita ID | 公開 |
|---|---|---|
| ai-coding-preflight-checklist | `b8dacca4ce2d9079454a` | public |
| ai-dev-team-small-issues-for-agents | `b13950837889d97479fc` | public |
| river-reviewer-agent-skills | `607d78c35745b17f9bc8` | public（Codex判断で private:true→false） |

## このPRの内容
- 公開準備（ignorePublish:false / updated_at / 内部HTMLコメント削除）
- qiita-cli が書き戻した id / updated_at の反映
- **publish失敗の根因修正**: `ai-coding-preflight-checklist` の title に未クオートの `: `（コロン+空白）→ YAMLがネストmap誤認しfrontmatter全体崩壊 → 全フィールド型エラー。title をシングルクオートで囲んで解消
- scope-creep 相互参照を実Qiita URL（`a25ec91`）へ差し込み

## Codex合意の要点
- 公開順: preflight → small-issues → river-reviewer（1本ずつ publish、都度 id 書き戻り確認）
- river-reviewer は OSS体験談のため限定共有でなく public 公開が筋
- リンクは本文末尾の関連リンク中心（宣伝過多回避）

## 検証
- `npm run check` 全パス（qiita-publish-hygiene 含む）
- slug↔id 乖離なし（`<slug>.md` から直接 publish、同一ファイルに id 書き戻り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)