### PR TITLE
docs(zenn): penpot-react記事のtopicsを内容整合タグへ修正

### DIFF
--- a/articles/penpot-react-design-system-contract.md
+++ b/articles/penpot-react-design-system-contract.md
@@ -2,7 +2,7 @@
 title: "PenpotとReactを同じ契約で運用するデザインシステムの作り方"
 emoji: "🎛️"
 type: "tech"
-topics: ["designsystem", "penpot", "react", "nextjs", "ai"]
+topics: ["designsystem", "penpot", "ai", "frontend", "ai駆動開発"]
 published: false
 ---
 


### PR DESCRIPTION
## 概要

`articles/penpot-react-design-system-contract.md` の topics を記事の実内容に合わせて差し替えます。

| 変更前 | 変更後 |
|---|---|
| `designsystem, penpot, react, nextjs, ai` | `designsystem, penpot, ai, frontend, ai駆動開発` |

## 理由

記事の主題は **Penpot×React のデザインシステム契約運用**（token JSON / component-map / AI へのデザイン指示 / 検証順）で、React・Next.js の実装コードや手順は登場しない。`react` / `nextjs` タグは「実装記事」を期待した読者とのミスマッチを生むため、デザインシステム・AI 運用寄りの内容整合タグへ修正する。

- `frontend`: フロントエンド層での発見性確保
- `ai駆動開発`: リポジトリ標準タグ。AI への UI 実装指示の運用が主題と整合

## 検証

- `npm run check`: OK（`check:zenn-title` / `check:fm-title` パス）
- `published: false` のため Zenn deploy 非トリガー

🤖 Generated with [Claude Code](https://claude.com/claude-code)