### PR TITLE
docs(publish-queue): Qiita 三部作 + PlanGate の段階公開スケジュールを追加

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -14,8 +14,14 @@
 | # | 締切 | platform | path | レビュー | 状態 |
 |---|---|---|---|---|---|
 | 2 | **2026-05-29（金）18:00 JST** | qiita | `Qiita/public/ai-coding-preflight-checklist.md` | Full（済 PR#247） | 未公開（ignorePublish:true）|
+| 3 | **2026-06-02（火）18:00 JST** | qiita | `Qiita/public/plangate-ai-coding-workflow.md` | Full（済 PR#283、4指摘反映済） | 未公開（ignorePublish:true）|
+| 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
+| 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
+| 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
 
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
+- #3〜#6 はデザイン三部作 Qiita 化＋PlanGate Qiita 化。Codex 助言に基づく段階公開（PlanGate → DESIGN.md → penpot-react → open-design）。1週ペース・初動の反応とタイトル調整余地を確保
+- #6（open-design）は Zenn 原典が 2026-05-26 週公開予定のため、Zenn 公開後の cross-post `:::note info` 有効化を**公開作業の前段**に組み込む（コメントアウト退避済み、手順は記事内 HTML コメントに記載）
 - 補充は手動。次テーマが決まったら行を追加（Rolling/テンプレは凍結中のため使わない）
 
 ## Done


### PR DESCRIPTION
## 概要

Qiita 4本の手動公開デッドラインを `docs/publish-queue.md` に追加（Codex 助言に基づく段階公開）。

| # | 締切 | slug | PR |
|---|---|---|---|
| 3 | 2026-06-02 | plangate-ai-coding-workflow | #283 ✅ |
| 4 | 2026-06-09 | design-md-guide-and-adoption-log | #285 ✅ |
| 5 | 2026-06-16 | penpot-react-design-system-contract | #286 ✅ |
| 6 | 2026-06-23 | open-design-design-quality | #286 ✅ |

## 設計判断（Codex 助言反映）

- 一斉公開（4本同時）ではなく**段階公開**を選択 — 初動の反応・タイトル・導線調整の余地を確保
- 1週ペース — `docs/publish-queue.md` 既存の「1件ずつ手動公開」ルールに整合
- #6（open-design）は Zenn 原典が 2026-05-26 週公開予定のため、Zenn 公開後の cross-post `:::note info` 有効化を公開作業の前段に組み込む（コメントアウト退避済み、手順は記事内 HTML コメントに記載）
- 全ファイル `ignorePublish: true` 維持＝**本 PR マージでも Qiita 公開は発生しない**

## 検証

- `npm run check`: 既存項目に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)