### PR TITLE
docs: 運用ポリシー・実測スナップショットを docs/ へ昇格

### DIFF
--- a/docs/channel-metrics/2026-05-21.md
+++ b/docs/channel-metrics/2026-05-21.md
@@ -1,0 +1,108 @@
+# Channel Metrics Snapshot — 2026-05-21
+
+[`content-channel-strategy.md`](../content-channel-strategy.md) の「Data-driven channel weighting」セクションの根拠となる実測値。次回計測時は新ファイル `docs/channel-metrics/YYYY-MM-DD.md` を作成し、戦略文書の参照リンクを差し替える。
+
+## 取得元と期間
+
+| 媒体 | 取得元 | 期間 |
+| --- | --- | --- |
+| Zenn | GA4（PV / UU / エンゲ時間）+ Zenn 公開 API（likes / 公開日） | GA4 表示期間（不明、ダッシュボード表示分） |
+| Qiita | GA4 + Qiita 公開 API（likes / stocks / created_at） | 同上 |
+| note | note 公開 API（likeCount + anonymousLikeCount / commentCount） | 全期間 |
+
+## 全体サマリ
+
+| 媒体 | PV | UU | 平均エンゲ | 反応合計 | 記事数 | 平均反応/記事 |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Zenn** | **9,345** | 5,717 | 32秒 | 250 likes | 27 | 9.3 |
+| Qiita | 160 | 107 | 39秒 | LGTM 6 / ストック 14 | 9（2026年公開分） | LGTM 0.7 / ストック 1.6 |
+| note | （GA未連携） | — | — | スキ 772（ログイン590+匿名182） | 26 | 29.7 |
+
+**確定事実**:
+- Zenn は Qiita の **約58倍** の流入規模。集客の主戦場
+- note の匿名スキ比率 24%（182/772）は他媒体にないチャネル特性
+
+## Zenn GA4 トップ10
+
+| # | PV | PV% | エンゲ秒 | いいね | 公開日 | スラッグ |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 4,172 | 46.08% | 39 | 72 | 2026-04-06 | design-md-guide-and-adoption-log |
+| 2 | 1,660 | 17.76% | 25 | 17 | 2026-05-04 | claude-code-to-codex-app-migration |
+| 3 | 732 | 7.83% | 25 | 5 | 2026-05-13 | codex-developer-instructions |
+| 4 | 564 | 6.04% | 24 | 7 | 2026-04-25 | dual-agent-repo-codex-and-claude-code |
+| 5 | 449 | 4.80% | 23 | 2 | 2026-04-23 | ai-generated-skill-md-reality-check |
+| 6 | 349 | 3.73% | 14 | 2 | 2026-04-22 | ai-agent-autonomy-boundary-with-memory |
+| 7 | 217 | 2.32% | 58 | — | — | /minewo（プロフィール） |
+| 8 | 170 | 1.82% | 42 | 67 | 2025-08-30 | obsidian-supermemory-mcp |
+| 9 | 158 | 1.69% | 24 | 3 | 2026-04-05 | github-copilot-auto-pr-workflow |
+| 10 | 129 | 1.38% | 18 | 2 | 2026-05-16 | multi-ai-discussion-roadmap-rewrite |
+
+**ハイライト**:
+- `design-md-guide-and-adoption-log` 単独で全 PV の **46%**（4,172）
+- 上位2本（DESIGN.md + Codex 移行）で **62%**
+- `obsidian-supermemory-mcp` は GA4 PV 170 に対し likes 67 = **PV/like 3** → Zenn 内バズ型の代表例
+
+## Zenn 集客 2タイプ（PV/like 比率）
+
+| タイプ | PV/like | 該当例 | 解釈 |
+| --- | --- | --- | --- |
+| **SEO 主導型** | 100〜200+ | ai-generated-skill-md-reality-check 224 / codex-developer-instructions 146 / claude-code-to-codex-app-migration 98 | 検索流入、フォロワー外まで届く |
+| **バランス型** | 50〜100 | design-md-guide 58 / dual-agent-repo 81 / github-copilot-auto-pr 53 / multi-ai-discussion 64 | 両経路で安定（入口記事の最有力） |
+| **Zenn 内バズ型** | 3〜10 | obsidian-supermemory-mcp 3 | フォロー新着・トレンド経由のコアファン拡散 |
+
+## Qiita GA4 トップ10
+
+| # | PV | エンゲ秒 | ストック | LGTM | 公開日 | タイトル |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 36 | 29 | 2 | 1 | 2026-05-18 | Claude CodeでAIが勝手に実装範囲を広げる対策 |
+| 2 | 23 | 29 | 2 | 1 | 2026-05-19 | AIコーディング前に確認する5項目 |
+| 3 | 16 | 23 | 2 | 0 | 2026-05-11 | River Reviewer を作った |
+| 4 | 16 | 40 | 2 | 1 | 2026-05-19 | Agent Skills River Reviewer 体験 |
+| 5 | 15 | 31 | 2 | 2 | 2026-05-19 | Issue は小さく切るほどチーム開発で扱いやすい |
+| 6 | 13 | 38 | 11 | 7 | **2021-02-04** | ThinkPad TrackPoint Keyboard II (JIS配列）をMacBookで使う |
+| 7 | 12 | 12 | 1 | 0 | 2026-04-16 | レビュー可能化のために決めておくこと |
+| 8 | 9 | 59 | 2 | 2 | **2022-10-31** | REALFORCE(Windows)をMacBookで使う |
+| 9 | 8 | 31 | 1 | 0 | 2026-04-16 | 2025年、AIコーディングエージェントを入れてわかったこと |
+| 10 | 8 | 18 | — | — | — | **404（旧 ID `93027e02e962ec327c2f`）** |
+
+**ハイライト**:
+- 公開 4〜5 年前のキーボード系記事（#6 / #8）が今も上位 = エバーグリーンの強さ
+- 旧 ID `93027e02e962ec327c2f` が **404 でも月8PV の残留トラフィック**
+
+## note トップ10（スキ計＝ログイン+匿名）
+
+| # | スキ計 | (ログイン+匿名) | 公開日 | タイトル |
+| --- | --- | --- | --- | --- |
+| 1 | 108 | 83+25 | 2021-12-09 | PjM / PdM / PO の違いとは |
+| 2 | 102 | 71+31 | 2024-02-08 | CTOとしての就任 |
+| 3 | 69 | 50+19 | 2022-09-28 | アイミツSaaS開発チーム Four Keys |
+| 4 | 56 | 43+13 | 2021-12-28 | webエンジニア採用 面接質問 |
+| 5 | 50 | 37+13 | 2022-12-09 | スクラム生産性 Four Keys と9つのメトリックス |
+| 6 | 49 | 39+10 | 2022-07-10 | EM / TL / PM の役割分担 |
+| 7 | 46 | 34+12 | 2021-11-12 | プロダクト開発にScrum導入 |
+| 8 | 44 | 31+13 | 2021-12-27 | スプリント0 ふり返り |
+| 9 | 36 | 26+10 | 2021-12-14 | Scrum 導入前夜・準備 |
+| 10 | 35 | 28+7 | 2023-01-13 | アジャイル開発のバックログ管理 |
+
+**ハイライト**: トップ10 のうち 7本が 2021〜2022 年公開。**long-tail evergreen 形成チャネル**として機能している。
+
+## 既知の運用課題
+
+### Qiita 旧 ID 404 残留トラフィック
+
+| ID | 状態 | 現状 |
+| --- | --- | --- |
+| `93027e02e962ec327c2f` | 404（削除済） | GA4 で月8PV の残留 |
+| `5ebff79112ecf1af872c` | 正規版（PlanGate v8.6.0 Metrics v1） | 現行 URL |
+
+`articles/plangate-v86-hook-enforcement.md` の参照は新 URL に訂正済（PR #284）。外部被リンクは制御不可のため、月8PV のロスは許容範囲として放置。
+
+### note GA4 未連携
+
+note の SEO 流入質を Zenn と定量比較できない状態。将来 GA4 連携できれば横断分析の精度が上がる。
+
+## 次回計測の指針
+
+- 次回タイミング: 2026-06 末（publish-queue 締切 #2〜#6 消化後）
+- 比較観点: DESIGN.md PV 推移 / Qiita 三部作の初動 PV / open-design Zenn の PV/like タイプ判定
+- 新ファイル: `docs/channel-metrics/2026-06-XX.md` として作成し、戦略文書からの参照リンクを差し替える

--- a/docs/content-channel-strategy.md
+++ b/docs/content-channel-strategy.md
@@ -44,6 +44,9 @@ This positioning connects the existing topics into a single recognizable categor
 
 GA4 と各媒体 API で取得した実測値（2026-05-21 時点）に基づく、Channel roles の補強と運用方針更新。次回測定で陳腐化判定。
 
+**詳細データ**: [`channel-metrics/2026-05-21.md`](./channel-metrics/2026-05-21.md) — トップ10一覧・PV/like 分類・既知課題のフル記録
+**公開操作の境界**: [`publish-operating-policy.md`](./publish-operating-policy.md) — 自律実行範囲・著者ゲート・rate-limit 遵守
+
 ### 流入規模（GA4 PV ベース）
 
 | 媒体 | PV | UU | 平均エンゲ | 媒体内最高 PV 記事 | 比率 |

--- a/docs/publish-operating-policy.md
+++ b/docs/publish-operating-policy.md
@@ -1,0 +1,81 @@
+# Publish Operating Policy
+
+公開作業の自律実行範囲・著者ゲート・停止条件を定義する。Codex 助言（2026-05-20 セッション）を起点に、`docs/content-channel-strategy.md`（媒体役割の正本）の運用補助として位置づける。
+
+## Status: canonical（操作ポリシーの正本）
+
+- 自律エージェント（Claude Code / Codex）が公開関連作業を進める際は、本ドキュメントの境界を遵守する
+- 著者の明示的な承認なしに「著者ゲート」を越えない
+- 規約・媒体役割の定義そのものは [`content-channel-strategy.md`](./content-channel-strategy.md) を参照（二重定義しない）
+
+## 自律実行範囲（agent が承認なしで実行可能）
+
+| 範囲 | 例 |
+| --- | --- |
+| 記事下書き作成 | `articles/*.md` / `Qiita/public/*.md`（`published:false` / `ignorePublish:true` 維持） |
+| 品質レビュー生成 | `reviews/zenn/*.md` / `reviews/qiita/*.md` |
+| 既存ドラフトへのレビュー指摘反映（採用/保留/却下の選別を含む） | 本文編集 + 反映状況サマリ |
+| publish-queue / 戦略ドキュメントの更新 | `docs/publish-queue.md` / `docs/content-channel-strategy.md` 等 |
+| WXR 生成（note インポート用ファイル） | `articles_note/build/*.xml`（gitignored） |
+| メトリクス取得・分析 | GA4 / 各媒体 API |
+| PR 作成・CI 通過後のマージ（**ただし以下の停止条件に該当しない場合のみ**） | `docs/` 系・`reviews/` 系・`ignorePublish:true` 維持の Qiita 系・`published:false` 維持の Zenn 系 |
+
+## 著者ゲート（agent 単独では実行しない・停止条件）
+
+以下のいずれかに該当する操作は、**著者の明示的な承認**を得るまで実行しない。
+
+| 境界 | 該当操作 |
+| --- | --- |
+| **publish フラグ変更** | `published: false → true`（Zenn） / `private: true → false`（Qiita） / `ignorePublish: true → false`（Qiita） |
+| **外部公開** | `npm run publish:qiita -- <slug>` の実行 |
+| **release/zenn 反映** | main → release/zenn の sync PR マージ（Zenn 本番 deploy 発火） |
+| **note 手動作業** | note.com 側での目次・タグ設定／公開判断／WXR インポート実行 |
+| **既存公開記事の本文書き換え** | Zenn / Qiita / note で `published:true` 相当の記事の本文修正（誤字訂正レベル除く） |
+| **大規模削除** | 複数記事の同時削除・ディレクトリ削除 |
+
+**判定原則**: 不可逆な外向き操作・公開影響が出る操作は全て著者ゲート。リバーシブルな内部整備（下書き作成・レビュー・ドキュメント更新）は自律可。
+
+## Rate-limit 遵守
+
+公開フローでは、自律実行範囲内であっても以下の制約に従う。
+
+| 項目 | 制約 |
+| --- | --- |
+| Zenn release/zenn rate-limit | 24h / 5本（公式仕様）。本リポジトリでは安全マージンとして **24h / 3本** を運用上限とする |
+| Zenn PR あたりの記事数 | 1 PR で release/zenn にマージする記事は最大 3本 |
+| Zenn PR 間隔 | 24時間以上あけてマージ |
+| 既存 update と新規 publish | 別 PR に分割（update が rate-limit に巻き込まれて公開済記事が古いままになる事故を防ぐ） |
+
+詳細は [`AGENTS.md`](../AGENTS.md) の「Zenn 公開フロー」と [memory `feedback-zenn-publish-rate-pacing`] を参照。
+
+## 自律実行時のチェックリスト
+
+agent が公開関連作業を進める際は、以下を満たすことを明示的に確認する。
+
+1. **作業前**: `gh auth status` で active account が `s977043` であること
+2. **作業前**: `gh pr list --state open` で並列セッションの重複 PR がないこと
+3. **作業前**: branch-impacting 操作の直前に `git branch --show-current` で意図ブランチであること
+4. **編集中**: `published:` / `private:` / `ignorePublish:` フラグの変更が含まれていないこと（含まれていたら停止）
+5. **PR 作成前**: `npm run check` が PASS すること
+6. **PR 作成前**: 変更ファイルが `docs/` `reviews/` `Qiita/public/*.md`（draft）`articles/*.md`（draft）に限定されていること
+7. **マージ前**: `gh pr view <n> --json mergeStateStatus` で `CLEAN` であること
+8. **マージ前**: CI（Content checks + Dependency review）が全て pass であること
+
+## メトリクス再計測サイクル
+
+- **頻度**: 月次または publish-queue の主要締切消化後
+- **記録先**: `docs/channel-metrics/YYYY-MM-DD.md` を新規作成（既存ファイルは上書きしない＝履歴保持）
+- **更新箇所**: `docs/content-channel-strategy.md` の「Data-driven channel weighting」セクションから最新スナップショットへ参照リンク差し替え
+- **判断観点**:
+  - DESIGN.md キラーコンテンツの PV シェア推移
+  - Qiita ストック数推移（LGTM は無視）
+  - note の long-tail スキ蓄積
+  - Zenn 集客 2タイプ（SEO 主導 / 内バズ）の比率変化
+
+## 関連ドキュメント
+
+- [`content-channel-strategy.md`](./content-channel-strategy.md) — 媒体役割の正本
+- [`publish-queue.md`](./publish-queue.md) — 締切付き公開キュー
+- [`channel-metrics/2026-05-21.md`](./channel-metrics/2026-05-21.md) — 直近の実測スナップショット
+- [`../AGENTS.md`](../AGENTS.md) — Zenn 公開フロー（release/zenn 経由）と Git 運用規約
+- [`../CLAUDE.md`](../CLAUDE.md) — Claude Code 固有のツールガイド


### PR DESCRIPTION
## 概要

memory に留まっていた運用ポリシー・実測スナップショットを `docs/` 配下へ昇格してドキュメント化する。

## 追加ファイル（2件）

### `docs/publish-operating-policy.md`
公開作業の自律実行範囲・著者ゲート・停止条件を canonical 化。Codex 助言（2026-05-20）の停止条件をリポジトリ内に固定。

### `docs/channel-metrics/2026-05-21.md`
GA4 と各媒体 API で取得した実測値のフル記録。Zenn 9,345 PV / Qiita 160 PV / note スキ 772 の集約と トップ10 表。

## 修正

`docs/content-channel-strategy.md` の Data-driven section に上記2ドキュメントへの参照リンクを追加。

## 設計判断

- memory は Claude/Codex セッション固有として残し、リポジトリ内 SSoT は docs 側
- スナップショットは日付付きファイル名で蓄積（上書きしない）

## 検証

- `npm run check`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)