### PR TITLE
docs(zenn): publish PlanGate design evolution article

### DIFF
--- a/articles/plangate-design-evolution-v3-to-v8.md
+++ b/articles/plangate-design-evolution-v3-to-v8.md
@@ -3,7 +3,7 @@ title: "PlanGate v3 から v8.6 までの設計変遷：AI コーディング統
 emoji: "🗺️"
 type: "tech"
 topics: ["ai", "claudecode", "oss", "automation", "harness"]
-published: false
+published: true
 ---
 
 **PlanGate は v3 から v8.6 までの 1 か月で、「AI に作業させる仕組み」から「AI を止め、観測し、再現可能にする統制ハーネス」へ育ちました。**


### PR DESCRIPTION
## Summary
- Publish `articles/plangate-design-evolution-v3-to-v8.md` by switching `published` from `false` to `true`.

## Release scope
- Single new Zenn article publish.
- Fits the release/zenn rule of at most 3 new articles per PR.

## Checks
- `npm run check:note-ref -- articles/plangate-design-evolution-v3-to-v8.md`
- `npm run check:zenn-title -- articles/plangate-design-evolution-v3-to-v8.md`
- `npm run check:fm-title -- articles/plangate-design-evolution-v3-to-v8.md`
- `git diff --check`

## Note
- `npm run check` currently stops at `zenn list:articles` with a zenn-cli stack trace before repository-specific checks complete.
