### PR TITLE
docs(zenn): publish open-design-design-quality

### DIFF
--- a/articles/open-design-design-quality.md
+++ b/articles/open-design-design-quality.md
@@ -3,7 +3,7 @@ title: "Open Designでデザイン品質を上げる：Penpot契約運用とDESI
 emoji: "🎚️"
 type: "tech"
 topics: ["designsystem", "penpot", "opendesign", "ai", "frontend"]
-published: false
+published: true
 ---
 
 :::message


### PR DESCRIPTION
## Summary
- publish-queue #8 を 5/26 → 5/25 (今日) に前倒し公開
- `articles/open-design-design-quality.md`: published false → true
- 前作（penpot-react / design-md-guide）への相互リンクは記事冒頭で既存
- Qiita版 cross-post note の有効化は #6 (6/23予定) に合わせて別タスクで実施

## Zenn rate-limit
- `npm run check:zenn-pace`: 過去24h で publish 切替 0件、安全圏
- 前回公開: 5/22 river-reviewer (再デプロイ 5/25) → 4日空き

## マージ後
release/zenn ブランチへ反映 → Zenn デプロイトリガー → live 公開確認