### PR TITLE
docs(qiita): publish plangate-ai-coding-workflow + sync queue with reality

### DIFF
--- a/Qiita/public/plangate-ai-coding-workflow.md
+++ b/Qiita/public/plangate-ai-coding-workflow.md
@@ -6,22 +6,13 @@ tags:
   - スクラム
   - ClaudeCode
   - TDD
-private: true
-updated_at: ''
+private: false
+updated_at: '2026-05-27T08:00:00+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開メモ（公開前に削除）:
-- 初期状態: private: true / ignorePublish: true（ローカル下書き）
-- Qiita へ限定共有: private: true / ignorePublish: false
-- 一般公開: private: false / ignorePublish: false
-- 公開当日に updated_at を更新し、本コメントを削除してから npm run check → publish:qiita
-- 元記事(Zenn): https://zenn.dev/minewo/articles/plangate-ai-coding-workflow
--->
 
 AIコーディングエージェントを実務で使い始めると、かなり高い確率で同じ壁にぶつかります。
 

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -13,8 +13,7 @@
 
 | # | 締切 | platform | path | レビュー | 状態 |
 |---|---|---|---|---|---|
-| 2 | **2026-05-29（金）18:00 JST** | qiita | `Qiita/public/ai-coding-preflight-checklist.md` | Full（済 PR#247） | 未公開（ignorePublish:true）|
-| 3 | **2026-06-02（火）18:00 JST** | qiita | `Qiita/public/plangate-ai-coding-workflow.md` | Full（済 PR#283、4指摘反映済） | 未公開（ignorePublish:true）|
+| 3 | **2026-06-02（火）18:00 JST** | qiita | `Qiita/public/plangate-ai-coding-workflow.md` | Full（済 PR#283、4指摘反映済） | 公開準備済（ignorePublish:false、5/27 前倒し公開）|
 | 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
@@ -30,3 +29,4 @@
 - 2026-05-21 zenn ai-agile-value-increases https://zenn.dev/minewo/articles/ai-agile-value-increases （PR #289 main / PR #290 release/zenn、予定6/6から前倒し公開）
 - 2026-05-22 zenn river-reviewer-v033-improvement-loop https://zenn.dev/minewo/articles/river-reviewer-v033-improvement-loop — 当初 5/22 rate-limit hit でデプロイ拒否、2026-05-25 に release/zenn 空 commit（4ded8e6）で再デプロイ→公開反映確認済
 - 2026-05-25 zenn open-design-design-quality https://zenn.dev/minewo/articles/open-design-design-quality （PR #305 main / PR #306 release/zenn、予定5/26から前倒し公開）
+- 2026-05-19 qiita ai-coding-preflight-checklist https://qiita.com/s977043/items/b8dacca4ce2d9079454a （queue 上に残存していた古い #2 を実態に合わせて Done へ移動）


### PR DESCRIPTION
## Summary
queue #3 plangate-ai-coding-workflow を 5/27 前倒し公開準備。同時に queue #2 が実態と乖離していたため Done へ整合化。

## 変更内容
### Qiita/public/plangate-ai-coding-workflow.md
- `private: true → false`
- `ignorePublish: true → false`
- `updated_at` 設定
- 公開前削除指示HTMLコメントを除去

### docs/publish-queue.md
- #2 ai-coding-preflight-checklist は 2026-05-19 に既に公開済み（id: b8dacca4ce2d9079454a）だったため Done へ移動
- #3 plangate-ai-coding-workflow を「公開準備済」に更新

## マージ後
`npm run publish:qiita -- plangate-ai-coding-workflow` で Qiita 公開実行

## 検証
- `npm run check`: qiita-publish-hygiene OK / 他は note-tables WARN（既存）と faq-coverage WARN（既存）のみ