### PR TITLE
docs(qiita): record plangate-ai-coding-workflow publish + add SNS share drafts

### DIFF
--- a/Qiita/public/plangate-ai-coding-workflow.md
+++ b/Qiita/public/plangate-ai-coding-workflow.md
@@ -1,14 +1,14 @@
 ---
-title: "アジャイルでAI駆動開発をどう回すか: PlanGateの考え方とテンプレート"
+title: 'アジャイルでAI駆動開発をどう回すか: PlanGateの考え方とテンプレート'
 tags:
-  - AI駆動開発
+  - TDD
   - アジャイル
   - スクラム
+  - AI駆動開発
   - ClaudeCode
-  - TDD
 private: false
-updated_at: '2026-05-27T08:00:00+09:00'
-id: null
+updated_at: '2026-05-27T06:43:40+09:00'
+id: 6041bbc2659412341d54
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -13,7 +13,6 @@
 
 | # | 締切 | platform | path | レビュー | 状態 |
 |---|---|---|---|---|---|
-| 3 | **2026-06-02（火）18:00 JST** | qiita | `Qiita/public/plangate-ai-coding-workflow.md` | Full（済 PR#283、4指摘反映済） | 公開準備済（ignorePublish:false、5/27 前倒し公開）|
 | 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
@@ -30,3 +29,4 @@
 - 2026-05-22 zenn river-reviewer-v033-improvement-loop https://zenn.dev/minewo/articles/river-reviewer-v033-improvement-loop — 当初 5/22 rate-limit hit でデプロイ拒否、2026-05-25 に release/zenn 空 commit（4ded8e6）で再デプロイ→公開反映確認済
 - 2026-05-25 zenn open-design-design-quality https://zenn.dev/minewo/articles/open-design-design-quality （PR #305 main / PR #306 release/zenn、予定5/26から前倒し公開）
 - 2026-05-19 qiita ai-coding-preflight-checklist https://qiita.com/s977043/items/b8dacca4ce2d9079454a （queue 上に残存していた古い #2 を実態に合わせて Done へ移動）
+- 2026-05-27 qiita plangate-ai-coding-workflow https://qiita.com/s977043/items/6041bbc2659412341d54 （PR #314 経由で公開、予定6/2から前倒し）

--- a/docs/share-drafts/2026-05-27.md
+++ b/docs/share-drafts/2026-05-27.md
@@ -1,0 +1,157 @@
+# SNS シェアドラフト集 — 2026-05-27 作成
+
+直近公開コンテンツの X 投稿用ドラフト。各記事 A型（主張先出し）、B型（問い投げ）、C型（連投スレッド）の3案。
+
+- 投稿パターン規約: `docs/content-channel-strategy.md` 準拠（タグは媒体1 + 内容2まで）
+- 投下スケジュールは末尾のテーブル参照
+- 投稿済みは `[x]` でチェック
+
+---
+
+## 1. Zenn / PenpotとReactを同じ契約で運用するデザインシステムの作り方
+URL: https://zenn.dev/minewo/articles/penpot-react-design-system-contract
+
+**A: 主張先出し**
+> Penpot と React の整合は「同期」ではなく「同じ契約を見る」で解く。
+> token JSON と component-map を正本にしてしまえば、Figma か Penpot かは本質ではない。
+> https://zenn.dev/minewo/articles/penpot-react-design-system-contract
+> #Zenn #デザインシステム
+
+**B: 問い投げ**
+> Penpot と React の整合をプラグインや同期コマンドで解こうとしていませんか？
+> その前に「正本どこ？」を決めると、9割の競合が消えました。
+> https://zenn.dev/minewo/articles/penpot-react-design-system-contract
+
+**C: 連投スレッド（3本）**
+> 1/3 Penpot と React の整合を、同期ではなく「同じ契約に従わせる」運用にした記録です。デザイン三部作 1/3。
+> 2/3 正本は `tokens/*.json` と `component-map.json`。Penpotでの編集は「提案」、採用は JSON 側に手で反映してから戻す一方向設計。
+> 3/3 https://zenn.dev/minewo/articles/penpot-react-design-system-contract
+
+---
+
+## 2. Zenn / DESIGN.md 導入ガイド: AI実装のための入口・契約・検証をどう整えるか
+URL: https://zenn.dev/minewo/articles/design-md-guide-and-adoption-log
+
+**A: 主張先出し**
+> AI 実装の前に「どこを見て、どのルールで、どう検証するか」を1枚に書く。
+> それが `DESIGN.md`。デザインシステム本体の代わりではなく、AI と人間の入口を揃えるための薄い1枚です。
+> https://zenn.dev/minewo/articles/design-md-guide-and-adoption-log
+> #Zenn #AI駆動開発
+
+**B: 問い投げ**
+> AIに UI 実装を頼むと、毎回同じ説明をしてませんか？
+> 入口 1 枚に圧縮した結果と、半年運用した実績を全部出しました。
+> https://zenn.dev/minewo/articles/design-md-guide-and-adoption-log
+
+**C: 連投スレッド（4本）**
+> 1/4 `DESIGN.md` は「デザインシステム本体」ではなく、AI と人間の入口を1枚に圧縮するためのファイルです。三部作 2/3。
+> 2/4 中身は4ブロック：① Read first（参照順）② Source of truth（正本の場所）③ Rules ④ 検証コマンド。それ以上は書かない。
+> 3/4 半年運用した結果、AIプロンプトが短くなり、レビュー観点が揃い、実装とデザインのズレ検出頻度が上がりました（記事内に実績ログ）。
+> 4/4 https://zenn.dev/minewo/articles/design-md-guide-and-adoption-log
+
+---
+
+## 3. Zenn / Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編
+URL: https://zenn.dev/minewo/articles/open-design-design-quality
+
+**A: 主張先出し**
+> 「Penpotに替えれば品質が上がる」は誤り。
+> 開放性は、契約と入口があってはじめて4経路（SVG差分・token往復・AI可読・フォーマット非依存レビュー）で品質に変換されます。
+> https://zenn.dev/minewo/articles/open-design-design-quality
+> #Zenn #デザインシステム
+
+**B: 問い投げ**
+> デザインツールを乗り換えるだけで「品質」って上がりますか？
+> 答えはNoで、契約と入口が無いと開放性は品質に変換されない、という話を書きました。
+> https://zenn.dev/minewo/articles/open-design-design-quality
+
+**C: 連投スレッド（3本）**
+> 1/3 Open Design を導入すると「なぜ」品質が上がるのか、4経路で整理しました。三部作 3/3。
+> 2/3 4経路：①SVGが差分で読める ②tokenが往復できる ③AIが読める ④レビューがフォーマット非依存。前作の契約と入口がここに乗る。
+> 3/3 https://zenn.dev/minewo/articles/open-design-design-quality
+
+---
+
+## 4. Qiita / アジャイルでAI駆動開発をどう回すか: PlanGateの考え方とテンプレート
+URL: https://qiita.com/s977043/items/6041bbc2659412341d54
+
+**A: 主張先出し**
+> AI駆動開発をスクラムに乗せる答えは「計画承認をAI実行のゲートにする」。
+> PlanGate の考え方とテンプレートを全部出しました。Backlog ツールを問わず使えます。
+> https://qiita.com/s977043/items/6041bbc2659412341d54
+> #Qiita #AI駆動開発
+
+**B: 問い投げ**
+> AIを入れたらスクラムが回らなくなった、という人へ。
+> 原因はモデルではなく、人間の承認ポイントを抜いたまま走らせていることだと考えています。
+> https://qiita.com/s977043/items/6041bbc2659412341d54
+
+**C: 連投スレッド（4本）**
+> 1/4 AI駆動開発をスクラムに乗せる実装例を Qiita に出しました。PlanGate の考え方とテンプレート全部です。
+> 2/4 鍵は「計画 → セルフレビュー → AIレビュー → 人間承認」の4段を、AIが1行書く前に挟むこと。
+> 3/4 ファイル分割（plan.md / todo.md / test-cases.md 等）は冗長に見えますが、AIが exec フェーズで計画を書き換える事故を防ぐ装置です。
+> 4/4 https://qiita.com/s977043/items/6041bbc2659412341d54
+
+---
+
+## 5. Zenn / River Reviewer v0.30→v0.33：Improvement Loop と applyTo Scoping 整備の半月
+URL: https://zenn.dev/minewo/articles/river-reviewer-v033-improvement-loop
+
+**A: 主張先出し**
+> プロンプトを磨くのをやめた。
+> チームのレビュー知識を Agent Skills に移して、Improvement Loop で自動的に育てる仕組みに替えた半月の記録。
+> https://zenn.dev/minewo/articles/river-reviewer-v033-improvement-loop
+> #AI駆動開発
+
+**B: 問い投げ**
+> AIレビューを「プロンプトの腕」に依存させ続けて、本当にチームでスケールしますか？
+> v0.30→v0.33 の4リリースで、レビュー知識の移し替えと applyTo スコープ整備の試行錯誤を書きました。
+> https://zenn.dev/minewo/articles/river-reviewer-v033-improvement-loop
+
+---
+
+## 6. Zenn / AI時代に、なぜアジャイルの価値はさらに高まるのか
+URL: https://zenn.dev/minewo/articles/ai-agile-value-increases
+
+**A: 主張先出し**
+> AIが速くなるほど、アジャイルの価値は下がる──ではなく、むしろ上がる。
+> 「短いサイクルで価値を確認する」原則が、AIの暴走を止める唯一の制御点になるからです。
+> https://zenn.dev/minewo/articles/ai-agile-value-increases
+> #アジャイル #生成AI
+
+---
+
+## 7. note / AI駆動開発はアジャイルにフィットするのか
+URL: https://note.com/mine_unilabo/n/n92b270e91110
+
+**A: 主張先出し**
+> AI駆動開発、そのままだとアジャイルにフィットしない。
+> 必要なのは「もっと賢いAI」ではなく「ハーネス設計」。PlanGate で人間承認を1ステップ挟むだけで、チームで運用可能になります。
+> https://note.com/mine_unilabo/n/n92b270e91110
+
+---
+
+## 8. note / いま本当に重要なAIエージェント論
+URL: https://note.com/mine_unilabo/n/n050f094c021d
+
+**A: 主張先出し**
+> AIエージェントの議論、モデル性能の話ばかりになっていませんか？
+> 本当に効くのは「停められる・追跡できる・改善できる」の運用設計。Claude Agent SDK / OpenAI Agents SDK が揃ってこっち寄りに動いてます。
+> https://note.com/mine_unilabo/n/n050f094c021d
+
+---
+
+## 投下スケジュール案（5/27 〜 5/30）
+
+| 日時 | 投稿 | 型 |
+|---|---|---|
+| 5/27 12:00 | #4 Qiita PlanGate | A（公開直後アピール） |
+| 5/27 21:00 | #3 Zenn Open Design | A |
+| 5/28 朝 | #1 Zenn penpot-react | C スレッド |
+| 5/28 夜 | #2 Zenn DESIGN.md ガイド | A |
+| 5/29 朝 | #6 Zenn ai-agile | B（議論喚起） |
+| 5/29 夜 | #7 note AI駆動アジャイル | A |
+| 5/30 朝 | #5 Zenn river-reviewer | A |
+| 5/30 夜 | #8 note エージェント論 | B |
+
+公開直後の即時シェアは A 型、24h以内追撃に C スレッド、議論喚起に B、を当てる構成。


### PR DESCRIPTION
## Summary
P1: Qiita 公開実行記録 + P2: SNS シェアドラフト保存（Codex 助言通り）。

## P1: Qiita 公開
- `Qiita/public/plangate-ai-coding-workflow.md`: `npm run publish:qiita` 実行で id 自動付与
  - id: null → 6041bbc2659412341d54
  - 公開URL: https://qiita.com/s977043/items/6041bbc2659412341d54
- `docs/publish-queue.md`: Queue #3 を Done へ移動（予定 6/2 → 5/27 前倒し）

## P2: SNS シェアドラフト
- `docs/share-drafts/2026-05-27.md`: 直近公開 8記事の X 投稿ドラフト
  - Zenn 三部作 + PlanGate Qiita + river-reviewer + ai-agile + note 2記事
  - A型（主張先出し）/ B型（問い投げ）/ C型（連投スレッド）の使い分け
  - 5/27〜5/30 投下スケジュール案

## 次のアクション
- ユーザーが SNS 投下開始（ドラフトから1日2本程度）
- 残 Qiita queue（#4 6/9 / #5 6/16 / #6 6/23）は週次ペース維持（Codex Q2推奨）
- AGENT_LEARNINGS.md 更新は次セッション（Codex Q4 後回し可）