### PR TITLE
docs: add Qiita→Zenn cross-post + 3 AGENT_LEARNINGS entries

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -891,6 +891,67 @@ note公式ヘルプには「`https://` URLの JPEG/PNG/GIF なら `<img>` で取
 
 ---
 
+### 2026-05-26 — release/zenn sync PR の競合は articles_note/drafts/ で頻発、main 側採用が標準 [Workflow] [Pattern]
+
+**観察**: main → release/zenn の sync PR を作ると、`articles_note/drafts/` の rename/rename / modify/delete / add/add が 10件超で頻発する。原因は (1) main で note import の dedup によりファイル名が ID 単位に書き換わる、(2) release/zenn 側は同期前の古い名前で残っている、の組み合わせ。手動解決していると 5〜10 分のロスが出る。
+
+**対策/学び**:
+- `git merge -X theirs origin/main` だけでは rename/rename / modify/delete / add/add は自動解決されない（unmerged が残る）
+- 残った unmerged を一括処理する手順:
+  ```bash
+  for f in $(git diff --name-only --diff-filter=U); do
+    if git ls-tree origin/main "$f" 2>/dev/null | grep -q .; then
+      git checkout --theirs -- "$f" && git add "$f"
+    else
+      git rm -f "$f"
+    fi
+  done
+  ```
+  → main にあれば main 版を採用、main に無ければ削除（release/zenn 側で残っている古いファイルを整理）
+- release/zenn の articles_note/ は Zenn deploy 対象外なので、main を全面採用しても deploy には影響しない
+- 採用後は `grep "^published:" articles/<対象>.md` で本来の deploy 対象（articles/）が想定通りか必ず検証
+
+**根拠**: 2026-05-26 PR #306 / #309 / #311 / #313 のいずれでも同パターンの競合が発生。`git ls-tree` フィルタで一括処理する手順を確立
+
+---
+
+### 2026-05-26 — 既存ガイド系記事への FAQ セクション横展開は SEO/可読性の両面で効く [Pattern] [Workflow]
+
+**観察**: 1記事 (design-md-guide) で末尾に置いた「FAQ」セクションが読者から強い反応を得たため、ガイド系8記事に横展開。3-5問 / 各回答 2-4 文 / 「やってみないと分からない」で逃げない断定型で揃えた結果、`### Q.` 単位で People Also Ask に拾われやすい形になった。
+
+**対策/学び**:
+- 横展開時のテンプレート:
+  - 見出し: `## <記事の主題>のFAQ`（記事ごとに固有名、design-md-guide だけは「DESIGN.md 導入ガイドのFAQ」のように完全形）
+  - Q&A: `### Q. <質問>` 改行 `A. <2-4文>` の Markdown 形式
+  - 回答は条件付き断定（「3日以上のタスクで」「Sonnet クラスで」のように前提を明示）
+- FAQ単独抜粋を想定して「本文の方針3」のような番号参照は括弧で意味を補う
+- 検査自動化: `scripts/check-article-faq-coverage.js` で「title に gnide keyword を含む or 2400+ 文字」を guide-type と判定、FAQ欠落を WARN（exit 0、強制力なし）
+- `### Q.` カウントは FAQ章内限定にすること（章外散在の Q.形式見出しを誤検出しないため）
+
+**根拠**: PR #310（8記事FAQ追加 + check script）、PR #312（セルフレビュー結果反映）。3ペルソナ + Codex 並列レビューで「見出し命名不整合」「定量回答の前提抜け」「本文番号参照の抜粋時不明化」が共通指摘として浮上
+
+---
+
+### 2026-05-27 — publish-queue.md は実態と乖離しやすい、公開実行直前に必ず id / web 状態を確認 [Workflow] [Gotcha]
+
+**観察**: `docs/publish-queue.md` の #2 ai-coding-preflight-checklist が「未公開（ignorePublish:true）/ 締切 5/29」と記載されたまま、実際は 2026-05-19 に Qiita 公開済み（id: b8dacca4ce2d9079454a）だった。queue だけ見て公開準備を進めると、二重公開や無駄な hygiene 修正に時間を使う。
+
+**対策/学び**:
+- 公開作業着手前の確認手順:
+  ```bash
+  # ローカル状態
+  grep "^id:\|^ignorePublish:" Qiita/public/<slug>.md
+  # web 状態（id が null でなければ確認）
+  curl -s -o /dev/null -w "%{http_code}" "https://qiita.com/s977043/items/<id>"
+  ```
+  → id が `null` でなく web 200 なら既公開。queue は更新せず単に Done へ移動するだけで済む
+- queue 更新 PR は公開実行 PR とは別にしない。同一 PR で「実態整合 + 公開準備」を扱う方が history が辿りやすい
+- `npm run publish:qiita -- <slug>` 実行後に id が frontmatter に自動付与されるので、その差分は別 commit にせず公開記録 PR にまとめる
+
+**根拠**: 2026-05-27 PR #314 で queue #2 整合化、PR #315 で id 反映と Done 移動を実施。Codex 助言「queue 状態は実態と乖離しやすい」を裏付け
+
+---
+
 <!--
 ## 追加時のテンプレート
 

--- a/Qiita/public/5ebff79112ecf1af872c.md
+++ b/Qiita/public/5ebff79112ecf1af872c.md
@@ -14,6 +14,10 @@ slide: false
 ignorePublish: false
 ---
 
+:::note info
+本記事は、Zenn に掲載した [AIコーディングを「比較で改善」できる土台にする：PlanGate v8.6.0のMetrics v1とGovernance](https://zenn.dev/minewo/articles/plangate-v86-hook-enforcement) を Qiita 向けに再構成したものです。
+:::
+
 ## はじめに
 
 AIコーディングエージェントを使っていると、最初の関心は「どこまで書けるか」になります。


### PR DESCRIPTION
## Summary
Codex 助言（P2 cross-post / P3 学び整理）の対応。

## P2: Qiita cross-post 補完
Qiita 公開済み記事のうち Zenn 原典へのリンクが欠けていた 1 件のみ修正:
- `Qiita/public/5ebff79112ecf1af872c.md` (PlanGate v8.6.0 Metrics)
  - 冒頭に `:::note info` で Zenn 原典へリンク

他の Qiita 公開済み記事は Zenn counterpart が無い (ai-dev-team-* / preflight-checklist) か既にリンク済み (river-reviewer / plangate-ai-coding-workflow)。

## P3: AGENT_LEARNINGS.md (3エントリ追記)
1. **release/zenn sync 競合の一括解決**: `articles_note/drafts/` の rename/rename / modify/delete を `git ls-tree origin/main` フィルタで一括処理する手順
2. **FAQ 横展開のテンプレート**: 8記事FAQ追加で確立した命名・回答スタイル・check スクリプト連携
3. **publish-queue 実態乖離の検知**: id + web 200 確認で二重公開や無駄な hygiene 修正を防ぐ手順

## Codex Q1〜Q4 への対応状況
- Q1 (次タスク): SNS投下はユーザー手動、本PRで cross-post + 学び整理を実施
- Q2 (cross-post価値): やる価値あり、対象1件のみ実施
- Q3 (SNS vs 学び): 学びを短く先回りで整理、SNSは別途 ユーザー側で投下
- Q4 (何もしない週): 週次ペース維持のため、新規公開は最大 6/9 #4 まで控える