### PR TITLE
chore(process): wire gh-account pre-push hook + add release/zenn sync helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,14 @@ python3 .claude/skills/note-export-import/scripts/verify_wxr.py articles_note/bu
 
 依存: `pip install --break-system-packages markdownify markdown`（`verify_wxr.py` は標準ライブラリのみ）
 
+## 初回セットアップ（リポジトリ毎に1回）
+
+```bash
+git config core.hooksPath scripts/hooks
+```
+
+これで `scripts/hooks/pre-push` が有効になり、`gh active account` が `s977043` でない状態の `git push` を自動でブロックする。緊急時バイパスは `git push --no-verify`。
+
 ## 作業開始時のチェックリスト
 
 1. 並列セッション衝突を回避するため `gh pr list --state open` で重複 PR がないか確認
@@ -76,7 +84,8 @@ python3 .claude/skills/note-export-import/scripts/verify_wxr.py articles_note/bu
 4. 対象ファイルがどのプラットフォームか確認（`@AGENTS.md` の配置規約表）
 5. `articles_note/published/` を触る場合は ⚠️ 規約を確認（`@AGENTS.md` 禁止事項）
 6. note 記事に画像を追加する場合: SVG → PNG 変換 → `articles_note/assets/` 配置 → **`file` でサイズ・寸法を確認**（プレースホルダ画像 <10KB を弾く） → main に先にマージ → WXR 生成の順序を守る。**WXR 生成は必ず `--base-url https://raw.githubusercontent.com/s977043/my-blog/main/articles_note/assets` を付ける**（未指定で画像参照が残ると `md_to_wxr.py` が exit 1 で失敗、意図的にローカル参照を残すなら `--allow-local-images`）
-7. **Zenn 公開系の作業を進める前に**、`@AGENTS.md` の「Zenn 公開フロー（release/zenn ブランチ経由）」を確認。`articles/*.md` の `published: true` 切替や本文修正は **`release/zenn` ブランチへの merge をもって公開**となる。`main` への push は Zenn deploy をトリガーしない（rate-limit 対策）。1 PR 最大 3 本 / 24 時間あけてマージ / 既存 update と新規 publish は別 PR、を厳守。**release/zenn 系 PR を作る前に `npm run check:zenn-pace` で過去 24h の publish 切替件数を確認**（5 件以上で FAIL exit、3 件以上で WARN）
+7. **Zenn 公開系の作業を進める前に**、`@AGENTS.md` の「Zenn 公開フロー（release/zenn ブランチ経由）」を確認。`articles/*.md` の `published: true` 切替や本文修正は **`release/zenn` ブランチへの merge をもって公開**となる。`main` への push は Zenn deploy をトリガーしない（rate-limit 対策）。1 PR 最大 3 本 / 24 時間あけてマージ / 既存 update と新規 publish は別 PR、を厳守。**release/zenn 系 PR を作る前に `npm run check:zenn-pace` で過去 24h の publish 切替件数を確認**（5 件以上で FAIL exit、3 件以上で WARN）。release/zenn への sync PR は `scripts/sync-release-zenn.sh "<commit message>"` で一括実行可能（`articles_note/drafts/` の rename/rename 競合を main 採用で自動解決）
+   - **公開キュー (`docs/publish-queue.md`) と実態の乖離チェック**: queue から記事を公開準備に着手する前に、対象ファイルの `id:` フィールドと `curl -s -o /dev/null -w "%{http_code}" "https://qiita.com/s977043/items/<id>"` で web 状態を確認する。**id が null でなく web 200 なら既に公開済み**なので queue を Done へ移動するだけで終わる。queue を信じて二重公開準備に進むと10分以上のロスになる（2026-05-27 #2 ai-coding-preflight-checklist で実際に発生）
 8. **`git switch -c <new>` 直後に `git branch --show-current` で意図ブランチと一致するか確認** — Round 5 並列セッション干渉対策（PR #203 で観測、`memory/project_parallel_session_metrics.md` 参照）。不一致なら commit を作らず停止
 9. 既存 Skill / Agent / Command で対応できないか確認（上記表）
 10. `@AGENT_LEARNINGS.md` で類似タスクの落とし穴を確認

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Git pre-push hook — gh CLI の active account が s977043 でなければ push を中止する。
+#
+# インストール（リポジトリ単位、1回だけ実行）:
+#   git config core.hooksPath scripts/hooks
+#
+# バイパス（緊急時、推奨しない）:
+#   git push --no-verify
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && cd ../.. && pwd)"
+CHECK="$SCRIPT_DIR/scripts/check-gh-account.sh"
+
+if [ ! -x "$CHECK" ]; then
+  exit 0  # スクリプトが無ければ素通り（CI 等で実行されるケースを想定）
+fi
+
+if ! "$CHECK"; then
+  echo "" >&2
+  echo "[pre-push] gh active account が想定外。s977043 に切り替えてから再 push してください:" >&2
+  echo "  gh auth switch --user s977043" >&2
+  echo "  gh auth setup-git" >&2
+  echo "" >&2
+  echo "緊急時のバイパス: git push --no-verify" >&2
+  exit 1
+fi

--- a/scripts/sync-release-zenn.sh
+++ b/scripts/sync-release-zenn.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/sync-release-zenn.sh
+# main → release/zenn sync を 1 コマンドで実行する。
+# 既知の競合パターン（articles_note/drafts/ の rename/rename, modify/delete, add/add）を main 採用で自動解決する。
+#
+# 使い方:
+#   scripts/sync-release-zenn.sh "<commit message>"
+#
+# 例:
+#   scripts/sync-release-zenn.sh "chore(release/zenn): sync from main — publish article-X"
+#
+# 前提:
+#   - 現在ブランチが release/zenn ではないこと（誤って origin/release/zenn を更新しないため）
+#   - gh active account が s977043 であること（pre-push hook で検証）
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 \"<commit message>\"" >&2
+  exit 2
+fi
+
+COMMIT_MSG="$1"
+BRANCH_NAME="release/zenn-sync-$(date +%Y-%m-%d-%H%M)"
+
+git fetch origin release/zenn main
+
+git switch -c "$BRANCH_NAME" origin/release/zenn
+
+# -X theirs で多くの conflict を main 採用、残りは下のループで処理
+set +e
+git merge -X theirs origin/main -m "$COMMIT_MSG"
+MERGE_RC=$?
+set -e
+
+# Unmerged paths を一括処理: main にあれば main 版採用、無ければ削除
+UNMERGED=$(git diff --name-only --diff-filter=U)
+if [ -n "$UNMERGED" ]; then
+  echo "[sync] resolving $(echo "$UNMERGED" | wc -l) unmerged files (main side wins)"
+  while IFS= read -r f; do
+    if git ls-tree origin/main "$f" 2>/dev/null | grep -q .; then
+      git checkout --theirs -- "$f"
+      git add "$f"
+    else
+      git rm -f "$f" >/dev/null
+    fi
+  done <<< "$UNMERGED"
+  git commit -m "$COMMIT_MSG"
+fi
+
+# 最終確認
+if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+  echo "[sync] FAIL: 解決できなかった conflict が残っています。手動で解決してください" >&2
+  git status --short >&2
+  exit 1
+fi
+
+echo ""
+echo "[sync] OK: $BRANCH_NAME に main を反映済み"
+echo "[sync] 次の手順:"
+echo "  git push -u origin $BRANCH_NAME"
+echo "  gh pr create --base release/zenn --title '$COMMIT_MSG'"


### PR DESCRIPTION
## Summary
PR #295〜#316 セッション振り返り（案A: 影響時間順 3件）の実装。

## A. ドキュメント追記（1件）
**publish-queue 実態乖離チェックの明文化**
- `CLAUDE.md` 作業開始時チェックリスト #7 に追記: queue から記事を公開準備に着手する前に `id` + `curl -w "%{http_code}"` で web 状態を確認
- 根拠: 2026-05-27 PR #314 で queue 上 #2 が未公開のまま実は公開済み（id: b8dacca4ce2d9079454a）で約10分の調査ロス

## B. 自動ガード（2件）
**release/zenn sync の機械化** (`scripts/sync-release-zenn.sh`)
- `-X theirs` で解決しない `articles_note/drafts/` の rename/rename / modify/delete を main 採用で自動解決
- 4回連続（PR #306/#309/#311/#313）の手動解決を1コマンド化、累計15分削減
- 使い方: `scripts/sync-release-zenn.sh "<commit message>"` → push → `gh pr create`

**gh active account の pre-push 検証** (`scripts/hooks/pre-push`)
- 既存の `scripts/check-gh-account.sh` を発火するフック
- `kominem-unilabo` のまま push して 403 になる事故を機械的にブロック
- セットアップ: `git config core.hooksPath scripts/hooks`（CLAUDE.md 冒頭に追加）
- バイパス: `git push --no-verify`

## Test plan
- [x] `bash -n` syntax check pass
- [x] `git config core.hooksPath scripts/hooks` 適用、s977043 active 状態で push 成功（本PRの push 時に hook が発火し OK 判定）
- [x] `npm run check` 全項目 OK / 既知の WARN のみ

## 関連セッション
- 前回の振り返り PR: #294
- 対象セッションのマージ済み PR: #295, #304-#316
- 発生したインシデント: rate-limit 警告（実害なし）、 queue 乖離、release/zenn rename/rename 競合 ×4、kominem-unilabo 認証ミス ×4

## 次回への carry-over
- 見出し命名の自動検査拡張（「シリーズの他の記事」一貫性チェック）
- AGENT_LEARNINGS 追記タイミング規約