### PR TITLE
docs(qiita): publish multi-ai-discussion-roadmap-rewrite (前倒し)

### DIFF
--- a/Qiita/public/multi-ai-discussion-roadmap-rewrite.md
+++ b/Qiita/public/multi-ai-discussion-roadmap-rewrite.md
@@ -6,32 +6,17 @@ tags:
   - Codex
   - Gemini
   - OSS
-private: true
-updated_at: ''
+private: false
+updated_at: '2026-05-28T07:00:00+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開メモ（公開前に削除）:
-- 初期状態: private: true / ignorePublish: true（ローカル下書き）
-- Qiita へ限定共有: private: true / ignorePublish: false
-- 一般公開: private: false / ignorePublish: false
-- 公開当日に updated_at を更新し、本コメントを削除してから npm run check → publish:qiita
-- 元記事(Zenn): https://zenn.dev/minewo/articles/multi-ai-discussion-roadmap-rewrite
-- 元記事(note): https://note.com/mine_unilabo/n/n5fe2e97b9600
-- 公開後に下記 :::note info を有効化して Zenn 原典リンクを表示
--->
-
-<!--
-Qiita 公開時に有効化する :::note info（コメントアウト解除して公開）:
 
 :::note info
 本記事は、note に掲載した [AIエージェント3種で戦略議論したら、OSSロードマップの主軸が根本から変わった話](https://note.com/mine_unilabo/n/n5fe2e97b9600) を Qiita 向けに再構成したものです。
 :::
--->
 
 私は PlanGate という、AI コーディングエージェント向けの軽量ガバナンスハーネスを個人 OSS として開発しています。
 

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -16,7 +16,6 @@
 | 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
-| 7 | **2026-06-30（火）18:00 JST** | qiita | `Qiita/public/multi-ai-discussion-roadmap-rewrite.md` | Zenn 公開済記事のクロスポスト（Zenn: 2026-05-15 / note: 2026-05-15） | 下書き（ignorePublish:true）／FAQ 5問追加済／公開時に :::note info コメント解除|
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
 - #3〜#6 はデザイン三部作 Qiita 化＋PlanGate Qiita 化。Codex 助言に基づく段階公開（PlanGate → DESIGN.md → penpot-react → open-design）。1週ペース・初動の反応とタイトル調整余地を確保
 - #6（open-design）は Zenn 原典が 2026-05-26 週公開予定のため、Zenn 公開後の cross-post `:::note info` 有効化を**公開作業の前段**に組み込む（コメントアウト退避済み、手順は記事内 HTML コメントに記載）


### PR DESCRIPTION
## Summary
Queue #7 を 6/30 → 5/28 (今日) に前倒し公開。

## 変更内容
- `private: true → false`
- `ignorePublish: true → false`
- `updated_at` 設定
- 公開メモ HTML コメント削除
- `:::note info`（note 原典 n5fe2e97b9600 リンク）を有効化
- `docs/publish-queue.md`: Queue #7 行を削除

## マージ後アクション
`npm run publish:qiita -- multi-ai-discussion-roadmap-rewrite` で Qiita API 公開実行