### PR TITLE
docs(qiita): record multi-ai-discussion published + move queue to Done

### DIFF
--- a/Qiita/public/multi-ai-discussion-roadmap-rewrite.md
+++ b/Qiita/public/multi-ai-discussion-roadmap-rewrite.md
@@ -1,14 +1,14 @@
 ---
-title: "AIエージェント3種で戦略議論したら、OSSロードマップの主軸が根本から変わった話"
+title: AIエージェント3種で戦略議論したら、OSSロードマップの主軸が根本から変わった話
 tags:
+  - OSS
+  - Gemini
+  - codex
   - AI駆動開発
   - ClaudeCode
-  - Codex
-  - Gemini
-  - OSS
 private: false
-updated_at: '2026-05-28T07:00:00+09:00'
-id: null
+updated_at: '2026-05-28T09:29:07+09:00'
+id: 4e89a93c2ebfb928e2b1
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -30,3 +30,4 @@
 - 2026-05-25 zenn open-design-design-quality https://zenn.dev/minewo/articles/open-design-design-quality （PR #305 main / PR #306 release/zenn、予定5/26から前倒し公開）
 - 2026-05-19 qiita ai-coding-preflight-checklist https://qiita.com/s977043/items/b8dacca4ce2d9079454a （queue 上に残存していた古い #2 を実態に合わせて Done へ移動）
 - 2026-05-27 qiita plangate-ai-coding-workflow https://qiita.com/s977043/items/6041bbc2659412341d54 （PR #314 経由で公開、予定6/2から前倒し）
+- 2026-05-28 qiita multi-ai-discussion-roadmap-rewrite https://qiita.com/s977043/items/4e89a93c2ebfb928e2b1 （PR #319 経由で公開、予定6/30から前倒し、note原典 n5fe2e97b9600 cross-post）


### PR DESCRIPTION
## Summary
PR #319 で公開実行した multi-ai-discussion-roadmap-rewrite の Qiita 公開記録。

- id: null → 4e89a93c2ebfb928e2b1
- updated_at: 2026-05-28T09:29:07
- 公開URL: https://qiita.com/s977043/items/4e89a93c2ebfb928e2b1
- publish-queue.md: Done に記録（予定 6/30 → 5/28 前倒し）