### PR TITLE
docs(qiita): sync updated_at after note cross-post republish

### DIFF
--- a/Qiita/public/ai-dev-team-test-first-agent-workflow.md
+++ b/Qiita/public/ai-dev-team-test-first-agent-workflow.md
@@ -6,7 +6,7 @@ tags:
   - 生成AI
   - AI駆動開発
 private: false
-updated_at: '2026-04-16T06:37:15+09:00'
+updated_at: '2026-05-28T12:16:01+09:00'
 id: fd5e5642efb40bfe4198
 organization_url_name: null
 slide: false

--- a/Qiita/public/plangate-ai-coding-workflow.md
+++ b/Qiita/public/plangate-ai-coding-workflow.md
@@ -7,7 +7,7 @@ tags:
   - AI駆動開発
   - ClaudeCode
 private: false
-updated_at: '2026-05-27T06:43:40+09:00'
+updated_at: '2026-05-28T12:14:06+09:00'
 id: 6041bbc2659412341d54
 organization_url_name: null
 slide: false

--- a/Qiita/public/river-reviewer-agent-skills.md
+++ b/Qiita/public/river-reviewer-agent-skills.md
@@ -7,7 +7,7 @@ tags:
   - 生成AI
   - AI駆動開発
 private: false
-updated_at: '2026-05-19T07:49:58+09:00'
+updated_at: '2026-05-28T12:14:09+09:00'
 id: 607d78c35745b17f9bc8
 organization_url_name: null
 slide: false


### PR DESCRIPTION
## Summary
PR #321 の note リンク追加を `npm run publish:qiita` で公開実行。自動更新された `updated_at` をリポジトリに記録。

## 公開反映済み（3本、note リンク確認済）
| 記事 | note リンク |
|---|---|
| plangate-ai-coding-workflow | n3aae6b5467b9 |
| river-reviewer-agent-skills | nd21c3f1df22e |
| ai-dev-team-test-first-agent-workflow | nc62d478194d3 |

## 注記
- ai-dev-team-test-first はローカルが Qiita 公開版(4/27)の上位互換（コード例・チェック表多数）だったため、`updated_at` を現在時刻に更新して公開。リモート固有の編集損失なしを diff で確認済み
- 本 PR は updated_at のみの差分（本文変更なし）