### PR TITLE
fix(qiita-drift): use Buffer.concat to avoid multibyte corruption

### DIFF
--- a/scripts/check-qiita-drift.js
+++ b/scripts/check-qiita-drift.js
@@ -34,11 +34,13 @@ function fetchItem(id) {
           resolve(null);
           return;
         }
-        let body = '';
-        res.on('data', (c) => (body += c));
+        // Buffer で受けて最後に UTF-8 デコードする。
+        // 文字列連結 (body += c) はマルチバイト文字がチャンク境界で分割されると破損するため不可。
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
         res.on('end', () => {
           try {
-            resolve(JSON.parse(body));
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
           } catch {
             resolve(null);
           }


### PR DESCRIPTION
## Summary
`check-qiita-drift.js` が日本語記事を全件 drift 誤検知していたバグを修正。

## 原因
`res.on('data', c => body += c)` で Buffer を文字列連結しており、UTF-8 マルチバイト文字がチャンク境界で分割されると置換文字（�）に化け、ローカルと不一致になっていた。PR #323 でガード追加後、レート制限解除後の full pass 検証で発覚（同期済みの multi-ai 記事まで drift 報告 → byte 800 で `エ` が `�` に化けていた）。

## 修正
`Buffer.concat(chunks).toString('utf8')` で受信完了後にまとめて UTF-8 デコード。

## 検証
- 修正前: WARN 4件（全て誤検知、実 drift なし）
- 修正後: `npm run check:qiita-drift` → **OK: drift なし (checked 16 / skip 3)**

## 関連
- PR #323（ガード初版）の後続バグ修正