### PR TITLE
docs(zenn-book): Codex配線とmetrics出力サンプル追加（収束ラウンド） (#325)

### DIFF
--- a/books/plangate-guide/01_quickstart.md
+++ b/books/plangate-guide/01_quickstart.md
@@ -43,6 +43,8 @@ bin/plangate doctor --fix --yes
 
 > `doctor` 単体は環境チェックだけで、Hook の配線はしません。**配線には `doctor --fix` が必要**です。配線しないと後述の EH-1 / EH-2 は発火しません。
 
+> 💡 **Codex CLI を使う場合**：v8.10.0 で Codex parity が入り、Claude Code の `.claude/settings.json` と同様に、Codex CLI 用の `.codex/hooks.json`（`eh-bridge.sh`）経由で同じ EH 系 Hook が発火します。どちらのエージェントでも「承認なし実装の検知」は同じように効きます。
+
 `bin/plangate` は単一の CLI エントリポイントです。主要なサブコマンドは次の通り（`bin/plangate help` 相当）。
 
 ```text

--- a/books/plangate-guide/06_scale.md
+++ b/books/plangate-guide/06_scale.md
@@ -63,23 +63,29 @@ bin/plangate keep-rate <TASK>
 
 ```text
 # Metrics summary: TASK-XXXX
-- events: 8
+- events: 9
 - events by type:
     - c3_decided: 1
     - exec_started: 1
+    - hook_violation: 2
     - v1_completed: 1
     - ...
-- modes: {'light': 1}
+- modes: {'standard': 1}
 
 ## Hook violations
-- total: 0
+- total: 2
+- by hook_id:
+    - EH-2: 1
+    - EH-6: 1
+- by result:
+    - block: 2
 
 ## Gate decisions
 - C-3: {'APPROVED': 1, 'CONDITIONAL': 0, 'REJECTED': 0}
 - V-1: {'PASS': 1, 'FAIL': 0, 'WARN': 0}
 ```
 
-「どの Hook が何回止めたか」「C-3 / V-1 がどう推移したか」が一目で分かります。見た目の可視化より、**後から比較できる構造化データ**として残すことを優先した設計です。
+`by hook_id` を見れば「**どの Hook が何回止めたか**」（この例では EH-2＝承認なし実装、EH-6＝スコープ外編集が各 1 回）が分かり、`Gate decisions` で「C-3 / V-1 がどう推移したか」が追えます。見た目の可視化より、**後から比較できる構造化データ**として残すことを優先した設計です。
 
 ここで主要指標になるのが **Keep Rate**（計画がどれだけ守られたか）です。これは `metrics` とは別の独立コマンド `bin/plangate keep-rate` で算出します。計画と実装の乖離、Hook が何回止めたか、C-3 / C-4 の判断がどう推移したか ―― こうした数字を retrospective や週次レビューに乗せることで、「**計画の精度が上がっているか**」を勘でなくデータで確認できます。
 

--- a/books/plangate-guide/06_scale.md
+++ b/books/plangate-guide/06_scale.md
@@ -59,6 +59,28 @@ bin/plangate metrics <TASK> --report --aggregate
 bin/plangate keep-rate <TASK>
 ```
 
+`--report` の出力は、たとえばこのような形です（何を見ればよいかのイメージ）。
+
+```text
+# Metrics summary: TASK-XXXX
+- events: 8
+- events by type:
+    - c3_decided: 1
+    - exec_started: 1
+    - v1_completed: 1
+    - ...
+- modes: {'light': 1}
+
+## Hook violations
+- total: 0
+
+## Gate decisions
+- C-3: {'APPROVED': 1, 'CONDITIONAL': 0, 'REJECTED': 0}
+- V-1: {'PASS': 1, 'FAIL': 0, 'WARN': 0}
+```
+
+「どの Hook が何回止めたか」「C-3 / V-1 がどう推移したか」が一目で分かります。見た目の可視化より、**後から比較できる構造化データ**として残すことを優先した設計です。
+
 ここで主要指標になるのが **Keep Rate**（計画がどれだけ守られたか）です。これは `metrics` とは別の独立コマンド `bin/plangate keep-rate` で算出します。計画と実装の乖離、Hook が何回止めたか、C-3 / C-4 の判断がどう推移したか ―― こうした数字を retrospective や週次レビューに乗せることで、「**計画の精度が上がっているか**」を勘でなくデータで確認できます。
 
 > Keep Rate は advisory（参考指標）であり、合否を機械的に決めるものではありません。「先週より計画の逸脱が減ったか」を会話の起点にするための数字です。


### PR DESCRIPTION
## 概要

収束判定ラウンド（品質Agent / Codex / Gemini）の結果、**3系統とも「出版可」**。品質Agent・Codex は「これ以上の改善は不要・収束」、Gemini のみ実質改善2点を提案。その2点を**実 PlanGate に基づき適用**し、改善を打ち止め。

## 適用した改善（Gemini 提案・実データ準拠）

- **01 Quickstart**: Codex CLI 利用時の Hook 配線（`.codex/hooks.json` / `eh-bridge.sh`、v8.10.0 Codex parity）を `.claude/settings.json` と並記。本書の「Claude Code / Codex」読者に対応（`.codex/hooks.json` の実在を確認）
- **06 Scale**: `metrics --report` の実出力サンプルを追加（`examples/sample-task/metrics-summary.md` 準拠）。「何を見ればよいか」を具体化

## 収束の明示

品質Agent・Codex はともに「残す価値のある改善は **NO**、追加加筆は水増しで本書の設計方針（変わらない原理を扱う）を侵食する」と判定。**本 PR で本文改善は打ち止め**とし、以降は go-live（release/zenn 公開フロー）へ。

## 検証

- `npm run check` exit 0 / preview 実機で 06 の bodyError ゼロ・表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)