### PR TITLE
docs(queue): PlanGate Book の公開を本日20:00以降に予定 (#325)

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -16,8 +16,8 @@
 | 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
-| 7 | **2026-06-30（火）18:00 JST** | zenn-book | `books/plangate-guide/`（全8章） | 3巡（セルフ/マルチエージェント/Gemini）＋PR#326-330 | 未公開（`published: false`）／**公開前提条件**: ①ChatGPT 作業 PR #331（図解・読者導線・SVG）マージ ②cover 画像用意 ③通し校正 ④`published: true` 切替（issue #325）|
-- #7 は **Zenn Book**（単発記事でなく book）。Zenn の publish rate-limit（24h/本数）は**記事用で book は別枠**だが、念のため記事 publish と同日マージを避ける。MVP コア（00+01+03+04+付録A）は完成済み、ChatGPT 並行作業（PR #331）の図解・導線確定を待って公開判断
+| 7 | **2026-06-01（日）20:00 JST 以降** | zenn-book | `books/plangate-guide/`（全9章） | 5系統×複数ラウンド収束（セルフ/品質Agent/事実Agent/Codex/Gemini=全員「出版可」）＋PR#326-347 | **公開準備完了**（main は `published: true`／全章 mermaid 図／cover 500×700 表示確認済／検証バージョン統一）。残: **release/zenn 同期＝go-live のみ**（本日 20:00 以降に実行予定）|
+- #7 は **Zenn Book**（単発記事でなく book）。Zenn の publish rate-limit（24h/本数）は**記事用で book は別枠**だが、念のため記事 publish と同日マージを避ける。**本文・図・cover・レビューは全て完了**。公開は本日 20:00 以降に `scripts/sync-release-zenn.sh` → release/zenn PR マージで実行（go-live は外向きアクションのため人間 GO 必須）。go-live 前に `npm run check:zenn-pace` で rate-limit を確認すること
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
 - #3〜#6 はデザイン三部作 Qiita 化＋PlanGate Qiita 化。Codex 助言に基づく段階公開（PlanGate → DESIGN.md → penpot-react → open-design）。1週ペース・初動の反応とタイトル調整余地を確保
 - #6（open-design）は Zenn 原典が 2026-05-26 週公開予定のため、Zenn 公開後の cross-post `:::note info` 有効化を**公開作業の前段**に組み込む（コメントアウト退避済み、手順は記事内 HTML コメントに記載）


### PR DESCRIPTION
## 概要

PlanGate Book の公開を**本日（2026-06-01）20:00 JST 以降**に予定。公開キュー #7 を実態に更新。

## 変更

- 締切: 6/30 → **本日 20:00 JST 以降**
- 状態: **公開準備完了**（全9章・各章 mermaid 図・cover 500×700 表示確認・`published: true`・5系統レビュー収束で全員「出版可」）
- 残タスク: **release/zenn 同期（go-live）のみ**。20:00 以降に人間 GO で実行
- go-live 前に `npm run check:zenn-pace` 確認を明記

## 補足

公開（release/zenn マージ）は取り消し困難な外向きアクションのため、20:00 以降に明示 GO のもと実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)