### PR TITLE
docs(queue): 多層レビュー記事を新規publishとして登録 (#9)

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -16,7 +16,9 @@
 | 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
+| 9 | **2026-06-04（水）以降** | zenn | `articles/multi-agent-book-review-workflow.md` | 2巡（マルチエージェント/Codex/Gemini=全員「公開可」収束） | 未公開（`published: false`、main済 PR#356）。**新規 publish**。本日21:14のupdate同期(#352/#354)とは別日・別PRで公開（新規publishとupdateを束ねない）。公開時 `published: true` 化→ `check:zenn-pace`→ 単独 release/zenn PR|
 - #7 (zenn-book) は **2026-06-01 公開完了**（下記 Done 参照）。本文・図・cover・5系統＋ultracode レビュー完了後、release/zenn PR #350 マージで go-live
+- #9 (zenn) は「Bookを多層AIレビューで作った話」。内容は収束済み・公開可。タイミングのみ分離（Book公開→update同期→新規publish の順で間隔を空ける）
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
 - #3〜#6 はデザイン三部作 Qiita 化＋PlanGate Qiita 化。Codex 助言に基づく段階公開（PlanGate → DESIGN.md → penpot-react → open-design）。1週ペース・初動の反応とタイトル調整余地を確保
 - #6（open-design）は Zenn 原典が 2026-05-26 週公開予定のため、Zenn 公開後の cross-post `:::note info` 有効化を**公開作業の前段**に組み込む（コメントアウト退避済み、手順は記事内 HTML コメントに記載）


### PR DESCRIPTION
## 概要

「Zenn Bookを多層AIレビューで作ったら…」記事（PR #356 で main 済み・`published:false`）の**公開判断**：内容は GO（2巡レビュー収束）だが、**タイミングを分離**して登録。

- 公開キュー #9：zenn 新規 publish、2026-06-04 以降
- pacing：本日 21:14 の update 同期（#352/#354）とは**別日・別 PR**（新規 publish と既存 update を束ねない）
- 公開手順：`published: true` 化 → `check:zenn-pace` → 単独 release/zenn PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)