### PR TITLE
feat(workflow): ultracode品質チェックのフロー改善（保存ワークフロー化+文書化+強化）

### DIFF
--- a/.claude/workflows/ultracode-quality-check.js
+++ b/.claude/workflows/ultracode-quality-check.js
@@ -1,0 +1,177 @@
+export const meta = {
+  name: 'ultracode-quality-check',
+  description: 'Exhaustive multi-agent quality check: per-target review + static media-risk scan + external link verification + adversarial filtering. Reusable across articles/books.',
+  whenToUse: 'When you want an exhaustive, convergence-aware quality gate on a set of Markdown targets (Zenn/Qiita articles or a Zenn book) before publishing. Catches real bugs that single-pass reviews miss, while adversarially rejecting padding.',
+  phases: [
+    { title: 'StaticScan', detail: 'media-specific & link pitfalls by grep (catches what text review misses)' },
+    { title: 'Review', detail: 'per-target deep review grounded in the implementation source' },
+    { title: 'Links', detail: 'external link liveness' },
+    { title: 'Verify', detail: 'adversarially filter proposed improvements to real value only' },
+    { title: 'Synthesize', detail: 'consolidate blockers / confirmed improvements / risks' },
+  ],
+}
+
+// ── args（呼び出し時に渡す） ───────────────────────────────────────────────
+//  {
+//    targets: ["books/plangate-guide/03_plan.md", ...]   // 必須: レビュー対象の .md 群
+//    implRepo: "/Users/user/Documents/GitHub/plangate"   // 任意: 事実照合の正本(コード/スキーマ/docs)
+//    platform: "zenn" | "qiita" | "zenn-book"            // 任意: 媒体(静的リスクの判定に使用)。既定 "zenn"
+//    links: ["https://...", ...]                          // 任意: 実在確認する外部リンク
+//    claim: "本書の主張/前提"                              // 任意: レビュー時に渡す文脈
+//  }
+const cfg = args || {}
+const TARGETS = Array.isArray(cfg.targets) ? cfg.targets : []
+const IMPL = cfg.implRepo ? `（事実照合の正本: ${cfg.implRepo}。コード/スキーマ/docs と必ず突き合わせる）` : '（実装の正本が与えられていない場合は、照合不能な指摘を低信頼として扱う）'
+const PLATFORM = cfg.platform || 'zenn'
+const LINKS = Array.isArray(cfg.links) ? cfg.links : []
+const CLAIM = cfg.claim ? `対象の主張/前提: ${cfg.claim}` : ''
+
+if (!TARGETS.length) {
+  return { error: 'args.targets（レビュー対象の .md パス配列）が未指定です。例: {targets:["articles/foo.md"], implRepo:"/path/to/impl", platform:"zenn"}' }
+}
+
+// 媒体ごとの「静的に検出できる落とし穴」。文章レビューでは出ない媒体仕様バグを grep で先回りする。
+const PLATFORM_PITFALLS = {
+  'zenn': [
+    'markdown 画像での SVG 参照（![](*.svg)）— Zenn は SVG を表示しない。mermaid か PNG/JPEG/WebP/GIF に',
+    'Book/記事間の相対パスリンク（](../ や ](./ や *.md）— 公開サイトで 404。Zenn フル URL に',
+    'frontmatter の published / title / topics(5個以内) / emoji の妥当性',
+  ],
+  'zenn-book': [
+    'markdown 画像での SVG 参照（![](*.svg)）— Zenn は SVG を表示しない。mermaid 化推奨',
+    'chapters に無い .md が book ディレクトリに混在（preview に「無題」表示）',
+    'Book→記事リンクの相対パス（公開サイトで 404）→ フル URL に',
+    'config.yaml の published/price/topics(5)/chapters とファイル名の一致、cover の比率(1:1.4=500x700)・破損(終端ffd9)',
+  ],
+  'qiita': [
+    'frontmatter: tags(5個以内) / private / id / ignorePublish の妥当性',
+    'Zenn 固有記法（:::message 等）の残存 — Qiita は :::note',
+    'コードブロックの言語指定漏れ / コピペで動かないサンプル（重複宣言など）',
+  ],
+}
+const pitfalls = (PLATFORM_PITFALLS[PLATFORM] || PLATFORM_PITFALLS['zenn']).map((p,i)=>`${i+1}. ${p}`).join('\n')
+
+const STATIC_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: { type: 'array', items: {
+      type: 'object', additionalProperties: false,
+      required: ['file','issue','severity'],
+      properties: {
+        file: { type: 'string' },
+        issue: { type: 'string', description: '静的に検出した媒体/リンクの問題（実際のパス・行を引用）' },
+        severity: { type: 'string', enum: ['blocker','warn'] },
+      }
+    }}
+  }
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['target','blockers','improvements','verdict'],
+  properties: {
+    target: { type: 'string' },
+    blockers: { type: 'array', items: { type: 'string' }, description: '出版を止める/読者を誤らせる問題。なければ空' },
+    improvements: { type: 'array', items: {
+      type: 'object', additionalProperties: false,
+      required: ['desc','value','accurate'],
+      properties: {
+        desc: { type: 'string' },
+        value: { type: 'string', enum: ['high','low'] },
+        accurate: { type: 'boolean' },
+      }
+    }},
+    verdict: { type: 'string', enum: ['publish-ready','needs-fix'] },
+  }
+}
+
+const LINK_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['results'],
+  properties: { results: { type: 'array', items: {
+    type: 'object', additionalProperties: false, required: ['url','ok','note'],
+    properties: { url:{type:'string'}, ok:{type:'boolean'}, note:{type:'string'} }
+  }}}
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['desc','isRealImprovement','reason'],
+  properties: {
+    desc: { type: 'string' },
+    isRealImprovement: { type: 'boolean' },
+    reason: { type: 'string' },
+  }
+}
+
+// ── Phase 1: 静的媒体リスクスキャン（文章レビューの盲点を埋める）────────────
+phase('StaticScan')
+const staticScan = await agent(
+  `次の Markdown 群を、媒体「${PLATFORM}」固有の落とし穴について静的に点検する（grep / Read で実ファイルを確認し、推測でなく実際の行を引用）。\n`+
+  `対象:\n${TARGETS.map(t=>'- '+t).join('\n')}\n\n`+
+  `点検する落とし穴:\n${pitfalls}\n\n`+
+  `見つかった問題を severity(blocker/warn) 付きで返す。問題なしなら findings は空配列。`,
+  { label: 'static-scan', phase: 'StaticScan', schema: STATIC_SCHEMA }
+)
+
+// ── Phase 2: 対象ごとの精読レビュー（実装正本と照合）──────────────────────
+phase('Review')
+const reviews = (await parallel(TARGETS.map(t => () =>
+  agent(
+    `Markdown「${t}」を出版前に厳しくレビューする。${IMPL} ${CLAIM}\n`+
+    `(1) 出版を止める/読者を誤らせる blockers、(2) 入れれば明確に価値が上がる improvements のみ。好み・水増しは value=low。`+
+    `各 improvement は実装と照合して accurate を判定。些細な「改善のための改善」は出さない。他対象との整合(用語/番号/挙動)も見る。`,
+    { label: `review:${t.split('/').pop()}`, phase: 'Review', schema: REVIEW_SCHEMA }
+  )
+))).filter(Boolean)
+
+// ── Phase 3: 外部リンク実在確認（任意）──────────────────────────────────
+phase('Links')
+let links = { results: [] }
+if (LINKS.length) {
+  links = await agent(
+    `次のURLが実在・到達可能か検証する。可能なら WebFetch で取得を試み、404/リンク切れを ok/note で返す。\nURL:\n${LINKS.map(u=>'- '+u).join('\n')}`,
+    { label: 'link-check', phase: 'Links', schema: LINK_SCHEMA }
+  )
+}
+
+// ── Phase 4: 改善提案の敵対的検証（水増しを却下）────────────────────────
+const candidates = reviews.flatMap(r =>
+  (r.improvements||[]).filter(i => i.value === 'high' && i.accurate).map(i => ({ target: r.target, desc: i.desc }))
+)
+phase('Verify')
+const verified = (await parallel(candidates.map(c => () =>
+  agent(
+    `改善提案を敵対的に検証する。提案:「${c.desc}」(対象: ${c.target})。${IMPL}\n`+
+    `この対象は既に複数回レビュー済みである前提で、提案が【本当に】読者価値を明確に上げる実改善か、それとも水増し/好み/方針違反かを判定する。`+
+    `デフォルトは isRealImprovement=false（疑わしきは却下）。実装と照合して正確かつ明確な価値がある場合のみ true。`,
+    { label: `verify:${c.target.split('/').pop()}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+  ).then(v => ({ ...c, ...v }))
+))).filter(Boolean)
+
+// ── Phase 5: 統合 ──────────────────────────────────────────────────────
+phase('Synthesize')
+const staticBlockers = (staticScan?.findings||[]).filter(f => f.severity === 'blocker')
+const staticWarns = (staticScan?.findings||[]).filter(f => f.severity === 'warn')
+const blockers = reviews.flatMap(r => (r.blockers||[]).map(b => ({ target: r.target, blocker: b })))
+const confirmed = verified.filter(v => v.isRealImprovement)
+const brokenLinks = (links.results||[]).filter(l => !l.ok)
+
+return {
+  summary: {
+    targets: TARGETS.length,
+    publishReady: reviews.filter(r => r.verdict === 'publish-ready').length,
+    staticBlockers: staticBlockers.length,
+    reviewBlockers: blockers.length,
+    brokenLinks: brokenLinks.length,
+    confirmedImprovements: confirmed.length,
+    rejectedImprovements: verified.length - confirmed.length,
+    goNoGo: (staticBlockers.length + blockers.length + brokenLinks.length) === 0 ? 'GO候補（要人手の実レンダリング確認）' : 'NO-GO（下記blocker解消が必要）',
+  },
+  staticBlockers, staticWarns,
+  blockers, brokenLinks,
+  confirmedImprovements: confirmed.map(v => ({ target: v.target, desc: v.desc, reason: v.reason })),
+  rejectedImprovements: verified.filter(v => !v.isRealImprovement).map(v => ({ target: v.target, desc: v.desc })),
+  perTarget: reviews.map(r => ({ target: r.target, verdict: r.verdict, blockers: r.blockers.length })),
+  note: 'このフローは「文章＋静的＋リンク＋敵対的検証」までを自動化する。媒体での実表示（mermaid 描画・cover・画像）は別途 Playwright 等で実レンダリング確認すること（エージェントは描画結果を見ない）。',
+}

--- a/docs/ultracode-quality-check-flow.md
+++ b/docs/ultracode-quality-check-flow.md
@@ -1,0 +1,85 @@
+# ultracode 品質チェックのフロー
+
+公開前の記事・Book に対する**網羅マルチエージェント品質チェック**の標準フロー。
+単発レビューがすり抜ける実バグを掘り当てつつ、敵対的検証で「水増し改善」を却下することを狙う。
+
+> 実体は再利用ワークフロー `.claude/workflows/ultracode-quality-check.js`。`Workflow({name:"ultracode-quality-check", args:{...}})` で呼ぶ。
+
+## いつ使うか
+
+- Zenn/Qiita 記事や Zenn Book を**公開する前の最終ゲート**
+- 複数回のレビューで「もう収束した」と思った後の**ダメ押し**（収束の罠対策）
+- 「誤りが信頼を壊す」成果物（技術書・サンプルコードを含む記事）に絞る（トークンコストがかかるため全件には使わない）
+
+## フロー全体
+
+```mermaid
+flowchart TD
+    A[StaticScan<br/>媒体・リンクの静的点検] --> S[Synthesize]
+    B[Review<br/>対象ごと精読+実装照合] --> V[Verify<br/>改善提案の敵対的検証]
+    L[Links<br/>外部リンク実在確認] --> S
+    V --> S[Synthesize<br/>blocker/確定改善/リスク統合]
+    S --> H[人手: 実レンダリング確認<br/>Playwright等]
+    H --> GO[公開判断]
+```
+
+| フェーズ | 何をするか | なぜ要るか |
+|---------|-----------|-----------|
+| **StaticScan** | 媒体固有の落とし穴を grep で静的検出（SVG 画像参照・相対リンク・frontmatter） | **文章レビューでは出ない媒体仕様バグ**を先回り（後述の学び①）|
+| **Review** | 対象ごとに並列精読。実装の正本（コード/スキーマ/docs）と照合 | 事実誤り・読者を誤らせる記述を捕捉 |
+| **Links** | 外部リンクの実在/到達確認 | リンク切れ防止 |
+| **Verify** | 各改善提案を「本当に価値があるか／水増しか」と**敵対的に判定**（既定は却下）| 過剰研磨の抑制（学び③）|
+| **Synthesize** | blocker / 確定改善 / リスクを構造化して返す | GO/NO-GO 判断材料 |
+| **（人手）実レンダリング** | Playwright 等で**実際の表示**を確認（mermaid 描画・cover・画像）| エージェントは描画結果を見ない（学び①）|
+
+## 使い方
+
+```js
+Workflow({ name: "ultracode-quality-check", args: {
+  targets: ["books/plangate-guide/03_plan.md", "books/plangate-guide/04_exec.md"],
+  implRepo: "/Users/user/Documents/GitHub/plangate",   // 事実照合の正本
+  platform: "zenn-book",                                 // zenn | qiita | zenn-book
+  links: ["https://github.com/s977043/PlanGate", ...],   // 任意
+  claim: "計画(Plan)の精度が成否の大半を決める…",          // 任意の文脈
+}})
+```
+
+返り値の `summary.goNoGo` と `staticBlockers` / `blockers` / `brokenLinks` / `confirmedImprovements` を見る。
+`confirmedImprovements` だけを反映し、`rejectedImprovements` は**入れない**（水増し回避）。
+
+## このフローが捕まえた実例（PlanGate Book）
+
+5系統レビュー（セルフ＋マルチエージェント3視点＋Codex＋Gemini）が「収束」と判断した**後**に実行し、見逃しを掘り当てた:
+
+- **承認記録 JSON のサンプルがスキーマ必須項目を欠く**（コピペで動かない）
+- **自動承認機能の説明が前提条件を落とし、本の核と矛盾**
+- 一方で「巻頭に版差注記」「付録に図」などの提案は**敵対的検証で却下**（水増し）
+
+## 学び（このフローの設計根拠）
+
+### ① 媒体での実表示は、文章レビューでは絶対に出ない
+Book の図を SVG で用意していたが、**Zenn は markdown 画像の SVG を表示しない**。これは Playwright で実レンダリングして初めて発覚した。
+→ 対策2段構え: **StaticScan で SVG 参照を静的検出**（先回り）＋ **公開前に実レンダリング確認を人手で必ず行う**（最終確認）。
+
+### ② 事実照合の正本を与える
+「実装の正本（コード/スキーマ/docs）」を `implRepo` で渡さないと、もっともらしいだけの指摘が混ざる。照合先があって初めて「スキーマ違反サンプル」のような実バグを掘り当てられる。
+
+### ③ レビューは足し算でなく「足す/却下を分ける」
+収束後のレビューは改善を出しすぎる。**敵対的検証（既定は却下）**で「本当に価値がある改善」だけを残す。`confirmedImprovements` のみ反映する運用を徹底する。
+
+### ④ 「収束」を疑う最終パスの価値
+複数レビューが「もう十分」と言っても、網羅的に並列で当てる最終パスは別の価値がある。ただし出た提案を全部入れると過剰研磨になるので ③ で選別する。
+
+## 公開前チェックリスト（このフロー＋人手）
+
+- [ ] `ultracode-quality-check` を実行し `staticBlockers` / `blockers` / `brokenLinks` が 0
+- [ ] `confirmedImprovements` を反映（`rejectedImprovements` は入れない）
+- [ ] **実レンダリング確認**（Playwright 等）: 図・cover・画像・コードブロックが実際に表示される
+- [ ] `npm run check`（list:books / qiita-publish-hygiene 等）exit 0
+- [ ] 公開は人間の最終判断（外向きアクション）。rate-limit / pacing を確認
+
+## 限界
+
+- トークンコストが大きい。全成果物に使わず、誤りが信頼を壊すものに絞る。
+- エージェントは**描画結果を見ない**。実レンダリング確認は代替不可（人手 or Playwright）。
+- 最終公開判断は人間が持つ。本フローは判断材料を増やす営み。


### PR DESCRIPTION
## 概要

使い捨てだった ultracode 品質チェックを **再利用可能化＋ドキュメント化＋強化**。4方向すべて対応。

## 1. 再利用可能な保存ワークフロー化

`.claude/workflows/ultracode-quality-check.js`
- `args` で対象を切り替え：`targets` / `implRepo`（事実照合の正本）/ `platform`（zenn・qiita・zenn-book）/ `links` / `claim`
- `Workflow({name:"ultracode-quality-check", args:{...}})` で任意の記事・Book に再利用可

## 2. フロー自体の強化

- 🔴 **StaticScan フェーズ新設**（最大の改善）：媒体固有の落とし穴（**SVG 画像参照**・相対リンク・frontmatter）を grep で静的検出。**今回 SVG 公開ブロッカーを文章レビューが捕捉できず Playwright でしか出なかった反省**を反映し、静的に先回りする
- **grounding**：`implRepo` で実装の正本を明示的に渡す
- **敵対的検証＋構造化出力**：水増しを既定却下し `confirmedImprovements` のみ返す

## 3. ドキュメント化

`docs/ultracode-quality-check-flow.md`
- フロー図 / 使い方 / 捕まえた実例 / 学び4点（媒体の実表示は人手 Playwright 必須 等）/ 公開前チェックリスト / 限界

## 検証

- `node --check` syntax OK、`npm run check` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)