### PR TITLE
chore(qiita): River Review republish の updated_at 同期

### DIFF
--- a/Qiita/public/5a4665e78c4bd1a5c1bc.md
+++ b/Qiita/public/5a4665e78c4bd1a5c1bc.md
@@ -7,7 +7,7 @@ tags:
   - コードレビュー
   - GitHubActions
 private: false
-updated_at: '2026-05-28T12:34:43+09:00'
+updated_at: '2026-06-03T09:32:45+09:00'
 id: 5a4665e78c4bd1a5c1bc
 organization_url_name: null
 slide: false

--- a/Qiita/public/river-reviewer-agent-skills.md
+++ b/Qiita/public/river-reviewer-agent-skills.md
@@ -7,7 +7,7 @@ tags:
   - 生成AI
   - AI駆動開発
 private: false
-updated_at: '2026-05-28T12:14:09+09:00'
+updated_at: '2026-06-03T09:32:45+09:00'
 id: 607d78c35745b17f9bc8
 organization_url_name: null
 slide: false

--- a/Qiita/public/sdd-tdd-nonblocking-agent.md
+++ b/Qiita/public/sdd-tdd-nonblocking-agent.md
@@ -7,7 +7,7 @@ tags:
   - マルチエージェント
   - ClaudeCode
 private: false
-updated_at: '2026-06-02T07:20:32+09:00'
+updated_at: '2026-06-03T09:32:45+09:00'
 id: 05934596111b9065465d
 organization_url_name: null
 slide: false


### PR DESCRIPTION
## 概要

River Review リネーム（#361）を Qiita 3記事へ `publish:qiita` で反映した結果の `updated_at` 同期 PR。**本文差分は `updated_at` のみ**（リネーム本体は #361 で適用済み、本PRはローカルgitをサーバ実体に追従させるだけ）。

## 対象記事（サーバ反映済み）

| id | 記事 |
|----|------|
| 5a4665e78c4bd1a5c1bc | AIコードレビューOSS「River Review」 |
| 607d78c35745b17f9bc8 | River Review × Agent Skills 体験 |
| 05934596111b9065465d | マルチエージェント開発の3原則 |

3記事とも Qiita 上で「River Reviewer」→「River Review」表示に更新済み。`npm run check:qiita-drift` = drift なし。

## 補足：qiita-cli pre-sync の落とし穴

`qiita publish` は冒頭で全記事 pull を行い、**作業ファイル == `.remote/` キャッシュ**のときサーバ内容で作業ツリーを巻き戻す。今回リネーム時に `.remote/` キャッシュも書き換えていたため初回 publish が旧内容を再投稿してしまった。作業ファイルを HEAD に復旧し `.remote/` と相違させたうえで `--force` 再実行して解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)