### PR TITLE
feat(tooling): 事故再発防止ガード3本（pre-commit / qiita-remote-cache / internal-links）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,20 @@ python3 .claude/skills/note-export-import/scripts/verify_wxr.py articles_note/bu
 git config core.hooksPath scripts/hooks
 ```
 
-これで `scripts/hooks/pre-push` が有効になり、`gh active account` が `s977043` でない状態の `git push` を自動でブロックする。緊急時バイパスは `git push --no-verify`。
+これで以下の Git hook が有効になる:
+
+- `scripts/hooks/pre-push` — `gh active account` が `s977043` でない状態の `git push` をブロック。バイパス: `git push --no-verify`
+- `scripts/hooks/pre-commit` — 以下を自動ブロックし、口頭チェックリスト依存だった最頻事故クラスを機械化する:
+  - **main 直 commit**（バイパス: `ALLOW_MAIN_COMMIT=1 git commit ...`）
+  - **`Qiita/public/.remote/` の混入**（qiita-cli 専用キャッシュ。commit 禁止）
+  - **AGENTS.md の `<claude-mem-context>` ブロック混入**（claude-mem の transient 記憶）
+  - **0-insertion リネーム取りこぼし**（`git mv` + 内容編集の同一 commit を WARN）
+  - 全チェックのバイパス: `git commit --no-verify`
+
+### 公開前ガード（自動実行）
+
+- `npm run publish:qiita` は wrapper（`scripts/publish-qiita.sh`）経由で、publish 直前に **`check:qiita-remote-cache`** を走らせる。`.remote/` キャッシュ手編集による pre-sync 巻き戻り（AGENT_LEARNINGS 2026-06-03）を検知して publish を止める。誤検知時のバイパス: `SKIP_REMOTE_CACHE_CHECK=1 npm run publish:qiita -- <slug>`
+- `npm run check` に **`check:internal-links`** を統合済み（Zenn 記事間リンク `/articles/<slug>` と画像 `/images/...` の実在検証、リネーム前旧表記の WARN）。
 
 ## 作業開始時のチェックリスト
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "list:books": "zenn list:books",
     "new:qiita": "qiita new --root Qiita",
     "pull:qiita": "qiita pull --root Qiita",
-    "publish:qiita": "qiita publish --root Qiita",
+    "publish:qiita": "bash scripts/publish-qiita.sh",
     "publish:qiita:all": "qiita publish --all --root Qiita",
     "check:qiita": "qiita version",
     "check:note-ref": "node scripts/check-note-reference.js",
@@ -21,7 +21,9 @@
     "check:fm-title": "node scripts/check-frontmatter-title-yaml.js",
     "check:faq-coverage": "node scripts/check-article-faq-coverage.js",
     "check:qiita-drift": "node scripts/check-qiita-drift.js",
-    "check": "npm run list:articles && npm run list:books && npm run check:qiita && npm run check:note-ref && npm run check:note-images && npm run check:note-tables && npm run check:qiita-publish-hygiene && npm run check:doc-freshness && npm run check:zenn-title && npm run check:fm-title && npm run check:faq-coverage"
+    "check:qiita-remote-cache": "node scripts/check-qiita-remote-cache.js",
+    "check:internal-links": "node scripts/check-internal-links.js",
+    "check": "npm run list:articles && npm run list:books && npm run check:qiita && npm run check:note-ref && npm run check:note-images && npm run check:note-tables && npm run check:qiita-publish-hygiene && npm run check:doc-freshness && npm run check:zenn-title && npm run check:fm-title && npm run check:faq-coverage && npm run check:internal-links"
   },
   "dependencies": {
     "zenn-cli": "^0.4.8"

--- a/scripts/check-internal-links.js
+++ b/scripts/check-internal-links.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Check: 記事内の「内部リンク切れ」を検出する。リネーム（例: #361 River Reviewer→River Review）で
+// slug 参照や相互リンクが壊れる事故クラスを機械検知する。
+//
+// `npm run check` に組み込むため、誤検知ゼロを最優先に保守的設計とする:
+//   FATAL（exit 1）にするのは、リポジトリ内で静的に実在検証できる参照のみ:
+//     1. Zenn 記事間リンク  /articles/<slug>  および  https://zenn.dev/minewo/articles/<slug>
+//        → articles/<slug>.md の実在を検証
+//     2. Zenn 画像の site-absolute 参照  /images/<path>  → images/<path> の実在を検証
+//   外部URL（qiita.com / note.com / 一般サイト）・相対パス・アンカーは検証対象外（FP 回避）。
+//
+//   WARN（非 FATAL）: 記事本文ディレクトリにリネーム前の旧表記が残っていないかを参考表示。
+//     旧表記リストは RENAMED_TERMS で管理（slug/URL に残る正規の語は除外する設計）。
+//
+// 対象: articles/**.md, Qiita/public/*.md（.remote 除く）, articles_note/**.md
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+
+// 旧表記 WARN（表示文字列のみ。slug/URL に含まれる小文字 river-reviewer は正規参照なので対象外）
+const RENAMED_TERMS = ['River Reviewer'];
+
+function walk(dir, acc) {
+  if (!fs.existsSync(dir)) return acc;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '.remote' || entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, acc);
+    else if (entry.name.endsWith('.md')) acc.push(full);
+  }
+  return acc;
+}
+
+function articleFiles() {
+  const acc = [];
+  walk(path.join(ROOT, 'articles'), acc);
+  walk(path.join(ROOT, 'Qiita', 'public'), acc);
+  walk(path.join(ROOT, 'articles_note'), acc);
+  return acc;
+}
+
+const LINK_RE = /\]\(\s*([^)\s]+)/g;
+
+function extractTargets(content) {
+  const targets = [];
+  let m;
+  while ((m = LINK_RE.exec(content)) !== null) {
+    targets.push(m[1]);
+  }
+  return targets;
+}
+
+function checkTarget(target) {
+  // アンカー・クエリを除去
+  const clean = target.split('#')[0].split('?')[0];
+  if (!clean) return null;
+
+  // 1. Zenn 記事間リンク（site-absolute / フル URL 両対応）
+  let slug = null;
+  const abs = clean.match(/^\/articles\/([A-Za-z0-9_-]+)$/);
+  const full = clean.match(/^https?:\/\/zenn\.dev\/minewo\/articles\/([A-Za-z0-9_-]+)$/);
+  if (abs) slug = abs[1];
+  else if (full) slug = full[1];
+  if (slug) {
+    const exists = fs.existsSync(path.join(ROOT, 'articles', `${slug}.md`));
+    return exists ? null : `Zenn 記事リンク切れ: ${target} → articles/${slug}.md が存在しない`;
+  }
+
+  // 2. Zenn 画像の site-absolute 参照
+  const img = clean.match(/^\/(images\/[^)]+)$/);
+  if (img) {
+    const exists = fs.existsSync(path.join(ROOT, img[1]));
+    return exists ? null : `画像リンク切れ: ${target} → ${img[1]} が存在しない`;
+  }
+
+  // それ以外は検証対象外（外部URL・相対パス・アンカー）
+  return null;
+}
+
+function main() {
+  const files = articleFiles();
+  const errors = [];
+  const warnings = [];
+
+  for (const file of files) {
+    const rel = path.relative(ROOT, file);
+    const content = fs.readFileSync(file, 'utf8');
+
+    for (const target of extractTargets(content)) {
+      const err = checkTarget(target);
+      if (err) errors.push(`  ${rel}: ${err}`);
+    }
+
+    for (const term of RENAMED_TERMS) {
+      if (content.includes(term)) {
+        const lines = content.split('\n');
+        lines.forEach((line, i) => {
+          if (line.includes(term)) {
+            warnings.push(`  ${rel}:${i + 1}: 旧表記「${term}」が残存`);
+          }
+        });
+      }
+    }
+  }
+
+  if (warnings.length > 0) {
+    console.warn(`[check:internal-links] WARN: 旧表記の残存 ${warnings.length} 件（要確認、非ブロッキング）`);
+    warnings.slice(0, 50).forEach((w) => console.warn(w));
+    if (warnings.length > 50) console.warn(`  ...他 ${warnings.length - 50} 件`);
+  }
+
+  if (errors.length > 0) {
+    console.error(`[check:internal-links] FAIL: 内部リンク切れ ${errors.length} 件`);
+    errors.forEach((e) => console.error(e));
+    return 1;
+  }
+
+  console.log(`[check:internal-links] OK: 内部リンク切れなし（checked ${files.length} files）`);
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/check-qiita-remote-cache.js
+++ b/scripts/check-qiita-remote-cache.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Check: qiita-cli `publish` の pre-sync 巻き戻り事故を publish 前に検知する。
+//
+// 背景（AGENT_LEARNINGS.md 2026-06-03）:
+//   `qiita publish` は冒頭で全記事 pull（syncArticlesFromQiita）を行い、
+//   その syncItem は「作業ファイル == .remote/<id>.md キャッシュ」のとき
+//   サーバ内容で作業ファイルを上書きする。
+//   一括 sed/置換スクリプトが .remote/ キャッシュも作業ファイルと同じ内容に
+//   書き換えてしまうと、publish 冒頭の pre-sync がサーバ旧内容で working を
+//   巻き戻し、旧内容を再投稿してしまう（リネームが永久にサーバへ届かない）。
+//
+// 検知ロジック:
+//   各 Qiita/public/<basename>.md について、
+//     - working（updated_at 無視）== .remote/<id>.md（updated_at 無視）  ← pre-sync が上書きする条件
+//     - かつ working（updated_at 無視）!= HEAD コミット版            ← 未公開のローカル編集がある
+//   の両方を満たすファイルは、.remote キャッシュが（qiita-cli 以外で）書き換えられた
+//   疑いが強く、このまま publish すると巻き戻る。FAIL で列挙し復旧手順を案内する。
+//
+// 使い方: publish:qiita の wrapper（scripts/publish-qiita.sh）が publish 直前に呼ぶ。
+//         手動確認は `node scripts/check-qiita-remote-cache.js`。
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PUBLIC_DIR = path.join(process.cwd(), 'Qiita', 'public');
+const REMOTE_DIR = path.join(PUBLIC_DIR, '.remote');
+
+// updated_at 行を除いて比較用に正規化（qiita-cli は updatedAt を等価判定に含めない）
+function normalize(content) {
+  return content
+    .split('\n')
+    .filter((line) => !/^updated_at:\s*/.test(line))
+    .join('\n')
+    .trim();
+}
+
+function getId(content) {
+  const m = content.match(/^id:\s*(.+)\s*$/m);
+  if (!m) return null;
+  const v = m[1].trim();
+  if (v === 'null' || v === '' || v === "''" || v === '""') return null;
+  return v.replace(/['"]/g, '');
+}
+
+function headVersion(relPath) {
+  try {
+    return execSync(`git show HEAD:"${relPath}"`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null; // HEAD に無い（新規ファイル）
+  }
+}
+
+function main() {
+  if (!fs.existsSync(PUBLIC_DIR)) {
+    console.log('[check:qiita-remote-cache] Qiita/public/ が無いため skip');
+    return 0;
+  }
+  const files = fs
+    .readdirSync(PUBLIC_DIR)
+    .filter((f) => f.endsWith('.md'));
+
+  const flagged = [];
+  for (const f of files) {
+    const abs = path.join(PUBLIC_DIR, f);
+    const working = fs.readFileSync(abs, 'utf8');
+    const id = getId(working);
+    if (!id) continue; // 未公開（id 無し）はサーバキャッシュも無いので対象外
+
+    const remotePath = path.join(REMOTE_DIR, `${id}.md`);
+    if (!fs.existsSync(remotePath)) continue; // キャッシュ未取得は対象外
+    const remote = fs.readFileSync(remotePath, 'utf8');
+
+    const relPath = `Qiita/public/${f}`;
+    const head = headVersion(relPath);
+
+    const nW = normalize(working);
+    const nR = normalize(remote);
+    const nH = head === null ? null : normalize(head);
+
+    // pre-sync が working を上書きする条件 && 未公開のローカル編集がある
+    if (nW === nR && nH !== null && nW !== nH) {
+      flagged.push({ file: relPath, id });
+    }
+  }
+
+  if (flagged.length > 0) {
+    console.error(
+      '[check:qiita-remote-cache] FAIL: .remote キャッシュが手編集された疑いがあります。',
+    );
+    console.error(
+      '  このまま publish すると pre-sync がサーバ旧内容で作業ツリーを巻き戻し、旧内容が再投稿されます。',
+    );
+    console.error('  対象:');
+    flagged.forEach((x) => {
+      console.error(`    - ${x.file} (id: ${x.id})`);
+    });
+    console.error('');
+    console.error('  復旧手順:');
+    console.error('    1) 作業ファイルが意図した内容（最新）であることを確認');
+    console.error(
+      '    2) .remote キャッシュをサーバ実体へ戻す: `npm run pull:qiita`（または該当 .remote/<id>.md を削除）',
+    );
+    console.error(
+      '    3) working と .remote が相違することを確認してから `npm run publish:qiita -- <slug> --force`',
+    );
+    console.error(
+      '  詳細: AGENT_LEARNINGS.md 2026-06-03「qiita publish の pre-sync 巻き戻し」',
+    );
+    return 1;
+  }
+
+  console.log(
+    `[check:qiita-remote-cache] OK: pre-sync 巻き戻りリスクなし（checked ${files.length}）`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Git pre-commit hook — 並列セッション干渉と commit 汚染の最頻事故クラスを機械ガードする。
+#
+# インストール（リポジトリ単位、1回だけ実行）:
+#   git config core.hooksPath scripts/hooks
+#
+# 検出する事故クラス（いずれも AGENT_LEARNINGS.md に実例記録あり）:
+#   1. main への直 commit（並列セッションのブランチ干渉で誤って main に積む）
+#   2. Qiita/public/.remote/ の混入（qiita-cli 専用キャッシュ。手編集・commit 禁止）
+#   3. AGENTS.md の <claude-mem-context> ブロック混入（claude-mem の transient 記憶）
+#   4. 0-insertion リネーム取りこぼし（git mv と Edit を同一 commit にして内容編集が欠落）
+#
+# バイパス:
+#   ALLOW_MAIN_COMMIT=1 git commit ...   # 1 のみ許可（main で正当に作業する稀ケース）
+#   git commit --no-verify                # 全チェックを skip（非推奨）
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")" && cd ../.. && pwd)"
+FAIL=0
+
+# --- 1. main 直 commit ガード -------------------------------------------------
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"
+if [ "$BRANCH" = "main" ] && [ "${ALLOW_MAIN_COMMIT:-}" != "1" ]; then
+  echo "[pre-commit] BLOCK: main へ直接 commit しようとしています。" >&2
+  echo "  作業ブランチを切ってください: git switch -c <branch>" >&2
+  echo "  main で正当に作業する場合のみ: ALLOW_MAIN_COMMIT=1 git commit ..." >&2
+  FAIL=1
+fi
+
+# staged ファイル一覧（追加・変更・名前変更後のパス）
+STAGED="$(git diff --cached --name-only --diff-filter=ACMR)"
+
+# --- 2. Qiita/public/.remote/ 混入ガード -------------------------------------
+REMOTE_HITS="$(echo "$STAGED" | grep -E '(^|/)Qiita/public/\.remote/' || true)"
+if [ -n "$REMOTE_HITS" ]; then
+  echo "[pre-commit] BLOCK: qiita-cli 専用キャッシュ Qiita/public/.remote/ が staged されています。" >&2
+  echo "  これは commit してはいけません（pull/publish で再生成される）。unstage してください:" >&2
+  echo "$REMOTE_HITS" | sed 's/^/    git restore --staged /' >&2
+  FAIL=1
+fi
+
+# --- 3. AGENTS.md の claude-mem ブロック混入ガード ---------------------------
+if echo "$STAGED" | grep -qx "AGENTS.md"; then
+  if git diff --cached AGENTS.md | grep -q '<claude-mem-context>'; then
+    echo "[pre-commit] BLOCK: AGENTS.md に <claude-mem-context> ブロックが含まれています。" >&2
+    echo "  claude-mem の transient 記憶であり commit 禁止。破棄してから commit してください:" >&2
+    echo "    git restore --staged AGENTS.md && git checkout -- AGENTS.md" >&2
+    FAIL=1
+  fi
+fi
+
+# --- 4. 0-insertion リネーム取りこぼし WARN ----------------------------------
+# rename(R) を含むのに numstat の追加+削除合計が極小なら、内容編集の取りこぼし疑い。
+RENAME_COUNT="$(git diff --cached --name-status --diff-filter=R | grep -c '^R' || true)"
+if [ "${RENAME_COUNT:-0}" -gt 0 ]; then
+  # 同名ファイルが working tree でまだ dirty（= 内容編集が未 stage）なら強警告
+  DIRTY_RENAMED="$(git diff --cached --name-only --diff-filter=R | while read -r f; do
+    if ! git diff --quiet -- "$f" 2>/dev/null; then echo "$f"; fi
+  done)"
+  if [ -n "$DIRTY_RENAMED" ]; then
+    echo "[pre-commit] WARN: rename 対象ファイルに未 stage の内容変更が残っています。" >&2
+    echo "  git mv + 内容編集を同一 commit にすると編集が取りこぼされる事例があります（AGENT_LEARNINGS 2026-05-17）。" >&2
+    echo "  意図した編集なら 'git add' し直してから commit してください:" >&2
+    echo "$DIRTY_RENAMED" | sed 's/^/    /' >&2
+  fi
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "" >&2
+  echo "[pre-commit] commit を中止しました。緊急バイパス: git commit --no-verify" >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/publish-qiita.sh
+++ b/scripts/publish-qiita.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Qiita publish wrapper — publish 直前に pre-sync 巻き戻りガードを走らせてから
+# qiita-cli の publish を実行する。
+#
+# 使い方（package.json 経由が標準）:
+#   npm run publish:qiita -- <slug> [--force]
+#
+# バイパス（ガードを skip。誤検知時のみ）:
+#   SKIP_REMOTE_CACHE_CHECK=1 npm run publish:qiita -- <slug>
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ "${SKIP_REMOTE_CACHE_CHECK:-}" != "1" ]; then
+  node "$REPO_ROOT/scripts/check-qiita-remote-cache.js"
+fi
+
+exec npx qiita publish --root Qiita "$@"


### PR DESCRIPTION
## 概要

ultracode 分析で **最大ROI** と判定された機械ガード3本。口頭チェックリスト依存だった最頻事故クラスを検知し再発を防ぐ。

## 追加するガード
1. **`scripts/hooks/pre-commit`** — main 直 commit / `Qiita/public/.remote/` 混入 / AGENTS.md の `<claude-mem-context>` 混入 をブロック、0-insertion リネームを WARN（バイパス: `ALLOW_MAIN_COMMIT=1` / `git commit --no-verify`）
2. **`scripts/check-qiita-remote-cache.js` + `scripts/publish-qiita.sh`** — pre-sync 巻き戻り事故（2026-06-03）を publish 前に阻止。`publish:qiita` を wrapper 経由化（バイパス: `SKIP_REMOTE_CACHE_CHECK=1`）
3. **`scripts/check-internal-links.js`**（`npm run check` 統合）— #361 型のリンク切れ検出。誤検知ゼロ優先で外部URL・相対パスは対象外

## 検証
- `npm run check` exit 0（89 files・リンク切れ 0）
- pre-commit / internal-links / qiita-remote-cache の正常系・異常系を動作確認済み

quick wins は PR #365。本PRは独立マージ可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)