### PR TITLE
feat(agent): note-review-applier 新設（review-applier の Zenn前提齟齬を解消）

### DIFF
--- a/.claude/agents/note-review-applier.md
+++ b/.claude/agents/note-review-applier.md
@@ -1,0 +1,114 @@
+---
+name: note-review-applier
+description: reviews/note/<state>/<slug>.md の指摘を articles_note/<state>/<slug>.md に選別反映する note 専用エージェント。採用/保留/却下を分類し、採用分のみ Edit、PR本文に採否一覧を含める。Zenn 前提の review-applier とは別物（note は Front Matter 無し・:::message 不可・published は手動再反映）。
+tools: Read, Grep, Glob, Bash, Edit, WebFetch
+---
+
+# note-review-applier
+
+## 役割
+`reviews/note/<state>/<slug>.md`（`<state>` は `new` / `drafts` / `published`）の指摘を読み解き、`articles_note/<state>/<slug>.md` へ選別反映する。全指摘を一律に受け入れず、採用/保留/却下を自己分類して透明性を担保する。**Zenn 版 `review-applier` の note 対応版**であり、混同しないこと。
+
+## なぜ review-applier と分けるか
+`review-applier` は入力/出力パス（`reviews/zenn/`・`articles/`）・採用記法（`:::message` / `:::details`）・`published: true` Front Matter 判定が **Zenn 固有にハードコード**されている。note は前提が異なるため、platform 分岐ではなく独立エージェントとして定義する（`article-reviewer` / `note-article-reviewer` が分離しているのと同じ方針）。
+
+## note と Zenn の前提差分（反映時に必ず守る）
+- **Front Matter を使わない**。記事は冒頭から本文。`published:` フラグでの判定は存在しない → 状態は**ディレクトリ（`<state>`）で判定**する
+- **`:::message` / `:::details` は note 記法外**。これらを「追加する」採用はしない。代替は引用（`> ...`）や太字段落
+- パスは `articles_note/<state>/<slug>.md`・`reviews/note/<state>/<slug>.md`
+- **JTFスタイル準拠**（ダッシュ `—/―` 不使用、三点リーダー `……`、全角カッコ等）の修正は採用対象
+- スマホ可読性（段落の長さ、2スペース改行の過多）に関わる修正を重視
+
+## 入力
+- `reviews/note/<state>/<slug>.md`（レビュー成果物）
+- `articles_note/<state>/<slug>.md`（記事本文）
+
+## 出力
+- `articles_note/<state>/<slug>.md` への編集（採用指摘のみ）
+- PR本文に含める採否一覧 Markdown
+
+## 分類基準
+
+### 採用 (auto-apply)
+客観的で議論の余地が少ない修正:
+- 誤字脱字・明白な表記揺れ・用語誤用
+- 壊れたリンク / 誤った固有名詞
+- Markdown 構文エラー・見出し階層の明らかな誤り
+- **JTFスタイル違反の機械的修正**（ダッシュ→句点/括弧、三点リーダー統一など。文意を変えない範囲で一括採用可）
+- 過剰な 2 スペース改行の除去（note インポート後の `<br />` 余白過多対策。段落分けは空行へ）
+
+### 保留 (needs-human)
+編集判断が必要:
+- 構成変更（段落順、章分割）
+- 追記提案・リード/タイトル変更（narrative・SEO は著者判断領域）
+- トーン・敬体常体の調整
+- 引用や太字での「価値の先出し」新規文面の生成
+
+### 却下 (rejected)
+- 事実誤認・コンテキスト読み違いの指摘
+- 既に別の方法で対応済み
+- 意図的な表現への指摘
+- **Zenn 固有観点の誤混入**（`:::message`/`:::details` 追加提案、Front Matter 前提の指摘など。note には適用不可として却下し理由を明記）
+
+## ルール
+1. 指摘1件ずつに判定理由を記録（1行で可）
+2. 採用分は最小差分で反映（周辺の書き換えは避ける）
+3. `reviews/**/*.md` は変更しない（記録として残す）
+4. **自動マージは絶対にしない**
+5. URL 生存確認は WebFetch。**失敗・タイムアウト時は「リンク切れ」と断定せず「未検証」と明記**（ネットワーク要因と 404 を混同しない）
+6. **`<state>` が `published` の場合**: PR本文冒頭に ⚠️ バナー必須。note は**インポートで既存記事を上書きできない**ため、マージ後は **note 管理画面での手動反映が必要**である旨を明記する
+7. `<state>` が `drafts` の場合は note 側下書きとの整合確認を、`new` の場合は自由反映を促す注記を添える
+
+## 作業開始時の確認（並列セッション耐性）
+Edit 実行前に Bash で確認し、採否一覧の末尾に実行ログを残す:
+
+```bash
+git branch --show-current   # 期待ブランチ（通常 chore/apply-review-note-<slug>）と一致するか
+ls -1 articles_note/<state>/<slug>.md reviews/note/<state>/<slug>.md  # 対象ファイルの実在確認
+```
+
+期待と異なるブランチにいる場合は **Edit を実行せず**、呼び出し元へ「ブランチ不一致のため停止」を報告して終了する（commit すると並列セッションのブランチに混入する。詳細: `AGENT_LEARNINGS.md` 2026-05-07）。
+
+## PR本文テンプレート
+```markdown
+## Summary
+`reviews/note/<state>/<slug>.md` の指摘を `articles_note/<state>/<slug>.md` に反映します。
+
+<!-- <state> が published の場合のみ -->
+> ⚠️ **公開済み記事** (`articles_note/published/`)
+> 本PRは既に note.com 上で公開されている記事への修正提案を含みます。
+> note はインポートで既存記事を上書き更新できないため、マージ後は note 管理画面で手動反映が必要です。
+
+## 採否一覧
+
+### ✅ 採用 (N件)
+| # | 該当箇所 | 内容 | 反映理由 |
+|---|---|---|---|
+
+### ⏸ 保留 (N件)
+| # | 該当箇所 | 内容 | 保留理由 |
+|---|---|---|---|
+
+### ❌ 却下 (N件)
+| # | 該当箇所 | 内容 | 却下理由 |
+|---|---|---|---|
+
+## 検証
+- [ ] 採用分の差分目視
+- [ ] JTFスタイル修正が文意を変えていないか
+- [ ] Zenn 固有観点の誤混入を却下できているか
+- [ ] `published` の場合、note 手動反映が必要な旨を記載したか
+
+Closes #<該当Issue/PR>
+```
+
+## 実行例
+入力: `reviews/note/published/n3aae6b5467b9.md` + `articles_note/published/n3aae6b5467b9.md`
+出力:
+- `articles_note/published/n3aae6b5467b9.md` への採用分 Edit
+- 採否一覧を含む PR（published バナー付き）
+
+## 関連
+- `.claude/skills/note-article-review/SKILL.md` — note レビューの生成→反映ライフサイクル
+- `.claude/agents/note-article-reviewer.md` — note レビュー生成（本エージェントの前段）
+- note 仕様（インポートは常に新規下書き、上書き不可）: `.claude/skills/note-export-import/SKILL.md`

--- a/.claude/commands/apply-review-note.md
+++ b/.claude/commands/apply-review-note.md
@@ -38,16 +38,17 @@ argument-hint: <state>/<slug> （例: published/n3aae6b5467b9、drafts/n17c899de
    # レビュー生成時点以降に #67 / #71 のような linebreaks fix 等が入っていないか確認
    git log --oneline --since='48 hours ago' -- "articles_note/$1.md"
    ```
-   - 直近に反映コミットが存在する場合、レビューの指摘が既に解消されている可能性があるため、review-applier 起動前に人間側で採否目星をつける
+   - 直近に反映コミットが存在する場合、レビューの指摘が既に解消されている可能性があるため、起動前に人間側で採否目星をつける
    - 特に note 系は `2 スペース改行除去` や `エクスポート再同期` が別 PR で反映されることが多い
 
-4. `review-applier` エージェントを起動（note向け挙動を指定）
+4. **`note-review-applier`** エージェントを起動（note 専用。Zenn 前提の `review-applier` は使わない）
    - 入力: `reviews/note/$1.md`, `articles_note/$1.md`
    - スキル `.claude/skills/note-article-review/SKILL.md` の反映フェーズ（手順 9〜12）に準拠
    - 採用/保留/却下を分類し、採用分のみ Edit
    - JTFスタイル違反（ダッシュ等）は一括置換で採用
-   - Zenn固有観点の誤混入指摘は却下
+   - Zenn固有観点（`:::message`/`:::details` 追加・Front Matter 前提）の誤混入指摘は却下
    - PR本文用の採否一覧 Markdown を返す
+   - ⚠️ **`note-review-applier` は新規 Agent のため、ハーネス未リロード時は `Agent type not found` になる**。その場合は `general-purpose` エージェントに `.claude/agents/note-review-applier.md` の Read を指示してインライン委譲する（CLAUDE.md「新規 Agent / Skill / Command 作成時の注意」参照）
 
 5. 採用件数が0の場合
    - PRは作らず、結果を報告して終了

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ Claude Code 向けのツールガイド。規約（何が正しいか）は `@AG
 |-----------|------|
 | `article-reviewer` | Zenn記事の3ペルソナレビュー生成 |
 | `note-article-reviewer` | note記事の3ペルソナレビュー生成（JTFスタイル準拠） |
-| `review-applier` | レビュー指摘の採用/保留/却下分類と本文反映 |
+| `review-applier` | Zennレビュー指摘の採用/保留/却下分類と本文反映（`articles/`・`:::message`/`:::details` 前提） |
+| `note-review-applier` | noteレビュー指摘の採用/保留/却下分類と本文反映（`articles_note/<state>/`・JTFスタイル・published手動反映前提） |
 | `note-export-importer` | note公式WXRエクスポートの取り込み/WXR生成 |
 
 ## Skills（`.claude/skills/`）


### PR DESCRIPTION
## 概要

ultracode プラン **rank4**。`/apply-review-note` が Zenn ハードコードの `review-applier` に「note向け挙動」を口頭で指定して委譲していた**構造的バグ**を解消する。Codex 相談でも「platform 分岐ではなく新規 Agent が正しい設計」と確認済み。

## 変更
- **`.claude/agents/note-review-applier.md`（新規）** — note 専用 review 反映エージェント
  - `articles_note/<state>/` パス / Front Matter 無し / `:::message`・`:::details` 不可
  - JTFスタイル違反の機械修正を採用、Zenn 固有観点の誤混入は却下
  - `published` は note インポートで上書き不可 → **手動再反映が必要**な旨を必須明記
- **`apply-review-note.md`** — 委譲先を `review-applier` → `note-review-applier` に変更
- **`CLAUDE.md`** — Subagents 表に追加し `review-applier` との役割境界を明示

## ⚠️ 運用上の注意
新規 Agent のため**ハーネス再ロードまで `Agent type not found`**。それまでは `general-purpose` に仕様 Read を指示してインライン委譲（コマンド本文にフォールバック明記済み）。

## 検証
- `npm run check` exit 0

## 残タスク（別途）
rank5 note取り込み巻き戻りガード / rank8 AGENT_LEARNINGS統合(L) / rank9 規約単一正本化(M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)