### PR TITLE
feat(note): wxr_to_md 取り込み前にローカル巻き戻りガードを追加（rank5）

### DIFF
--- a/.claude/skills/note-export-import/SKILL.md
+++ b/.claude/skills/note-export-import/SKILL.md
@@ -48,6 +48,7 @@ articles_note/
 3. ZIPを `articles_note/export/YYYY-MM-DD/` に**リネームせずに**配置（まだの場合）
 4. WXR (`note-*.xml`) + `assets/` を取得
 5. `scripts/wxr_to_md.py` で `published/` `drafts/` を再生成
+   - ⚠️ 取り込みは `published/` `drafts/` を server 状態で**上書き再生成**する。これらに未コミットのローカル編集があると巻き戻る（2026-04-26 で 2 記事巻き戻り事故）。スクリプトは取り込み前に `git status --short` で dirty を検出し、未コミット変更があれば **exit 1 で停止**する。先に commit/stash するか、編集が `new/` にあるべきか確認すること。意図して上書きする場合のみ `--force`
 6. `assets/` は最新エクスポート内容で上書き（ルートの `articles_note/assets/`）
 7. 差分をレビューしてコミット
 

--- a/.claude/skills/note-export-import/scripts/wxr_to_md.py
+++ b/.claude/skills/note-export-import/scripts/wxr_to_md.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import zipfile
@@ -110,11 +111,48 @@ def archive_zip(src: Path, out_root: Path) -> None:
         print(f"archived ZIP → {dst.relative_to(out_root)}")
 
 
+def check_local_regression(out_root: Path, force: bool) -> None:
+    """取り込みは published/ drafts/ を server 状態で上書き再生成する。
+    これらに未コミットのローカル編集があると、取り込みで巻き戻る（AGENT_LEARNINGS 2026-04-26）。
+    git 管理下なら取り込み前に dirty を検出し、上書き対象を警告する。"""
+    targets = [str(out_root / "published"), str(out_root / "drafts")]
+    try:
+        res = subprocess.run(
+            ["git", "status", "--short", "--", *targets],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return  # git 管理外 / git 不在なら素通り
+    dirty = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    if not dirty:
+        return
+
+    sys.stderr.write(
+        "\n[wxr_to_md] WARN: published/ drafts/ に未コミットのローカル変更があります。\n"
+        "  取り込みは server 状態でこれらを上書き再生成するため、未反映の編集が巻き戻ります:\n"
+    )
+    for ln in dirty:
+        sys.stderr.write(f"    {ln}\n")
+    sys.stderr.write(
+        "  対処: 先に commit/stash するか、編集が new/ にあるべきか確認してください。\n"
+        "  意図して上書きする場合は --force を付けて再実行してください。\n\n"
+    )
+    if not force:
+        sys.exit(1)
+    sys.stderr.write("[wxr_to_md] --force 指定のため続行します。\n")
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("src", type=Path, help="ZIP or extracted dir")
     ap.add_argument("--out", type=Path, default=Path("articles_note"), help="articles_note/ root")
+    ap.add_argument(
+        "--force", action="store_true",
+        help="published/ drafts/ に未コミット変更があっても取り込みを強行する",
+    )
     args = ap.parse_args()
+
+    check_local_regression(args.out, args.force)
 
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)


### PR DESCRIPTION
## 概要

ultracode プラン **rank5**。note WXR 取り込み（`wxr_to_md.py`）が `published/` `drafts/` を server 状態で**上書き再生成**する際、未コミットのローカル編集が巻き戻る事故（2026-04-26 で 2 記事巻き戻り）を防ぐ stop-gap。

## 設計
Codex 相談で「事後 diff 提示より**事前 git-dirty ガード**が単純・確実」と確認。`README.md` も `drafts/` は手編集しない前提（再生成上書き）と明記しており、危険なのは「`published/`/`drafts/` を手編集した状態で取り込みが走る」ケース。

- `wxr_to_md.py`: 取り込み前に `git status --short -- articles_note/published/ articles_note/drafts/` で dirty 検出。未コミット変更があれば上書き対象を列挙し **exit 1 で停止**。`--force` で強行可。git 管理外/git 不在なら素通り。
- `SKILL.md`: 取り込み手順に巻き戻り警告と `--force` を注記。

## 検証
- 構文 OK / clean 時素通り / dirty 時 exit 1 停止を確認 / `npm run check` exit 0

## 残タスク
rank8（AGENT_LEARNINGS 980行統合・L）: rank9（#369）マージ後に別PRで着手。

🤖 Generated with [Claude Code](https://claude.com/claude-code)