### PR TITLE
docs(queue): #9 Zenn 公開＋note Hermes 公開を Done へ記録

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -16,7 +16,6 @@
 | 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
-| 9 | **2026-06-04（水）以降** | zenn | `articles/multi-agent-book-review-workflow.md` | 2巡（マルチエージェント/Codex/Gemini=全員「公開可」収束） | 未公開（`published: false`、main済 PR#356）。**新規 publish**。本日21:14のupdate同期(#352/#354)とは別日・別PRで公開（新規publishとupdateを束ねない）。公開時 `published: true` 化→ `check:zenn-pace`→ 単独 release/zenn PR|
 - #7 (zenn-book) は **2026-06-01 公開完了**（下記 Done 参照）。本文・図・cover・5系統＋ultracode レビュー完了後、release/zenn PR #350 マージで go-live
 - #9 (zenn) は「Bookを多層AIレビューで作った話」。内容は収束済み・公開可。タイミングのみ分離（Book公開→update同期→新規publish の順で間隔を空ける）
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
@@ -27,6 +26,8 @@
 
 ## Done
 
+- 2026-06-04 note hermes-introduction-note https://note.com/mine_unilabo/n/nc1ac531190c9 （新規 note 公開、WXR インポート→手動公開。`articles_note/new/hermes-introduction-note.md` は編集の正本として残置、次回エクスポート取り込みで `published/nc1ac531190c9.md` が自動生成される）
+- 2026-06-04 zenn multi-agent-book-review-workflow https://zenn.dev/minewo/articles/multi-agent-book-review-workflow （queue #9。PR #372 main / PR #373 release/zenn でマージ→Zenn deploy 発火、多層AIレビュー収束済み）
 - 2026-06-02 qiita sdd-tdd-nonblocking-agent https://qiita.com/s977043/items/05934596111b9065465d （Zenn「仕様を揃えて止めない…3原則」cross-post、PR #353 改善反映、id:05934596111b9065465d）
 
 - 2026-06-01 zenn-book plangate-guide「AI にコードを書かせる前にやること — PlanGate 実践ガイド」 https://zenn.dev/minewo/books/plangate-guide （全9章/無料、PR #350 で release/zenn マージ→公開。5系統×複数ラウンド＋ultracode レビュー収束、cover 500×700。issue #325）


### PR DESCRIPTION
## 概要
2026-06-04 に完了した2件の公開を `docs/publish-queue.md` に反映。

| 種別 | 記事 | URL |
|------|------|-----|
| **新規 publish (queue #9)** | Zenn: multi-agent-book-review-workflow | https://zenn.dev/minewo/articles/multi-agent-book-review-workflow |
| **新規 publish** | note: hermes-introduction-note | https://note.com/mine_unilabo/n/nc1ac531190c9 |

## 変更
- Queue 表から **#9** 行を削除（Done へ移動）
- Done セクション冒頭に2件追加（2026-06-04 付）
- note Hermes は `articles_note/new/hermes-introduction-note.md` を編集の正本として残置（次回 note 公式エクスポート取り込みで `published/nc1ac531190c9.md` が自動生成）

## 検証
- `npm run check` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)