### PR TITLE
feat(commands): セッション運用パターンをコマンド化（振り返り A: check-session-state / post-merge-verify）

### DIFF
--- a/.claude/commands/check-session-state.md
+++ b/.claude/commands/check-session-state.md
@@ -1,0 +1,60 @@
+---
+description: セッション冒頭/節目に実施する状態確認ルーチンを一括実行する
+---
+
+# /check-session-state
+
+セッション冒頭・作業の節目で「ブランチ / 重複PR / 作業ツリー / check / rate-limit」を一括確認する。AGENT_LEARNINGS で繰り返し発生する事故クラス（並列セッション干渉・重複作業・claude-mem 混入・rate-limit 見落とし）の事前検知用。
+
+## 手順
+
+1. **アカウント** — push/PR が必要になる前段で確認
+   ```bash
+   gh auth status 2>&1 | grep -A1 "Active account: true" | head -2
+   ```
+   `s977043` でなければ `gh auth switch --user s977043`
+
+2. **ブランチ / 作業ツリー**
+   ```bash
+   git branch --show-current
+   git status --short
+   ```
+   - main 以外なら作業中ブランチを認識
+   - claude-mem 自動注入の `M AGENTS.md` を見たら CLAUDE.md §「`M AGENTS.md` は WIP ではない」を参照
+
+3. **重複 PR / DRAFT PR**
+   ```bash
+   gh pr list --state open --json number,title,isDraft --jq '.[] | "#\(.number) [\(if .isDraft then "draft" else "ready" end)] \(.title)"'
+   ```
+   並列セッション衝突回避（CLAUDE.md §作業開始時のチェックリスト 1〜2）
+
+4. **集約 check（記事構造・hygiene・リンク）**
+   ```bash
+   npm run check
+   ```
+   exit 0 でない場合は内訳を確認（faq-coverage WARN は非ブロッキング、CLAUDE.md 参照）
+
+5. **Zenn rate-limit pace（release/zenn 公開系を触る前は必須）**
+   ```bash
+   npm run check:zenn-pace
+   ```
+   過去 24h で 1 件以上 publish 切替があれば WARN。次の Zenn 公開は慎重に分散
+
+6. **Qiita drift（Qiita 作業を触る前推奨）**
+   ```bash
+   npm run check:qiita-drift
+   ```
+   レート制限時は当該記事を skip（誤検知しない）
+
+7. **直近マージ済 PR（前回作業の継続を把握）**
+   ```bash
+   gh pr list --state merged --limit 5 --json number,title --jq '.[] | "#\(.number) \(.title)"'
+   ```
+
+## 出力フォーマット
+
+ユーザーには上記7項目を**1メッセージ**で要約報告する。各項目を1〜2行に圧縮。問題があれば 🚩 を付ける。
+
+## 関連
+- `CLAUDE.md` §作業開始時のチェックリスト
+- `AGENT_LEARNINGS.md` §G CI/tooling / §D 並列セッション / §E GitHub account

--- a/.claude/commands/post-merge-verify.md
+++ b/.claude/commands/post-merge-verify.md
@@ -1,0 +1,63 @@
+---
+description: PR マージ後の事後検証を一括実行する（live URL 反映 / drift / 後片付け）
+argument-hint: <merged-pr-number> または <article-slug>（platform 自動判定）
+---
+
+# /post-merge-verify
+
+PR マージ直後に実施する事後検証ルーチン。AGENT_LEARNINGS で繰り返し発生する事故クラス（公開反映の見落とし / 後片付け忘れ / .remote 巻き戻り）の検知用。
+
+## 手順
+
+1. **引数の解釈**
+   - 数字なら PR 番号として `gh pr view <n>` で title / merged 状態を取得
+   - 文字列なら article slug として扱い、`articles/<slug>.md` `Qiita/public/<slug>.md` `articles_note/*/<slug>.md` のいずれかから platform を推定
+
+2. **main 同期 + 後片付け**
+   ```bash
+   git switch main && git pull --ff-only
+   git branch -d <merged-branch>          # 既に削除済みなら error は無視
+   git status --short
+   git stash list                          # セッション残置の確認
+   ```
+
+3. **live URL 反映確認（platform ごと）**
+   - **Zenn**: 公開済み記事の場合
+     ```bash
+     curl -s -o /dev/null -w "%{http_code}\n" "https://zenn.dev/minewo/articles/<slug>"
+     curl -s "https://zenn.dev/minewo/articles/<slug>" | grep -oE 'property="og:title" content="[^"]*"' | head -1
+     ```
+     200 + og:title が記事タイトルと一致すれば OK
+   - **Qiita**: id が frontmatter にあれば
+     ```bash
+     curl -s -o /dev/null -w "%{http_code}\n" "https://qiita.com/s977043/items/<id>"
+     ```
+   - **note**: 公開後の URL を引数 / ユーザー入力から取得
+     ```bash
+     curl -s -o /dev/null -w "%{http_code}\n" "https://note.com/mine_unilabo/n/<guid>"
+     ```
+
+4. **drift / 後続事故クラス検知**
+   ```bash
+   npm run check:qiita-drift           # Qiita 系を触った場合
+   npm run check:zenn-pace             # Zenn 公開系を触った場合
+   ```
+
+5. **release/zenn ↔ main 同期度**（Zenn 系のとき）
+   ```bash
+   git fetch origin main release/zenn
+   git diff origin/release/zenn..origin/main --stat -- articles/ books/
+   ```
+   差分が想定外なら申し送り
+
+6. **publish-queue 反映の要否**
+   - 新規公開なら `docs/publish-queue.md` の Done セクションへ追加候補（実体験 URL 必須）
+   - Queue 行を Done へ移すなら別 PR で（マージ済 PR と束ねない）
+
+## 出力フォーマット
+
+ユーザーには上記項目を**1メッセージ**で要約報告。✅ 通った項目 / 🚩 要対応項目を明示。
+
+## 関連
+- `CLAUDE.md` §セッション終了時のチェックリスト
+- `AGENT_LEARNINGS.md` §A Zenn / §B Qiita / §C note

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Claude Code 向けのツールガイド。規約（何が正しいか）は `@AG
 | `/review-note-article <state>/<slug>` | note記事の3ペルソナレビューを生成 | `articles_note/<state>/<slug>.md` |
 | `/apply-review-note <state>/<slug>` | noteレビューを本文に選別反映（PR作成） | `articles_note/<state>/<slug>.md` |
 | `/article-pipeline-note <state>/<slug>` | noteレビュー生成→反映を2PR分割で実行 | note記事 |
+| `/check-session-state` | セッション冒頭/節目の状態確認ルーチン（branch/PR/check/rate-limit/直近マージ）| 状態確認 |
+| `/post-merge-verify <pr#またはslug>` | PRマージ後の事後検証（live URL/drift/後片付け） | 公開反映確認 |
 
 ## Subagents（`.claude/agents/`）
 


### PR DESCRIPTION
## 概要

本セッション（2026-06-03〜04・15 PR）の振り返りで **Codex 助言の改善案 A** として採択した Slash Command 2 本を新設。15 PR を通して繰り返した「状態確認」「マージ後検証」を固定化し、ヒューマンエラー（並列セッション干渉・公開反映見落とし・drift）を予防する。

## 追加コマンド

### `/check-session-state`
セッション冒頭・節目に実施する状態確認ルーチン。
- アカウント / branch / 重複PR / 集約 check / zenn-pace / qiita-drift / 直近マージ
- AGENT_LEARNINGS §D 並列セッション / §E GitHub account / §G CI tooling を集約

### `/post-merge-verify <pr#またはslug>`
PR マージ直後の事後検証ルーチン。
- main 同期・後片付け / live URL HTTP+og:title 確認 / drift check / publish-queue 反映の要否
- AGENT_LEARNINGS §A Zenn / §B Qiita / §C note の反映確認を集約

## 設計判断（Codex 壁打ち結果）
- **A は反復頻度が高く、確認手順固定の価値あり**
- **不可逆操作を含まない**ため rank11「Qiita/release-zenn 系の非コマンド化」方針と整合
- B（公開系の半自動化）は痛みが再発するまで保留、E（publish-queue 構造化）は見送り

## 検証
- `npm run check` exit 0
- ハーネス認識済み（available skills 一覧に両コマンド列挙）

## 後続
別 PR で **C: AGENT_LEARNINGS テーマ別インデックス整合 check** を実装予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)