### PR TITLE
docs(zenn): レビュー反映 river-review-plugin-migration（オススメ一括採用 #4/#6/#8/#9）

### DIFF
--- a/articles/river-review-plugin-migration.md
+++ b/articles/river-review-plugin-migration.md
@@ -2,7 +2,7 @@
 title: "テンプレコピーをやめた — River Review を Claude Code / Codex の Plugin にした話"
 emoji: "🔌"
 type: "tech"
-topics: ["claudecode", "codex", "oss", "プラグイン", "agentskills"]
+topics: ["claudecode", "codex", "marketplace", "プラグイン", "agentskills"]
 published: false
 ---
 
@@ -43,7 +43,7 @@ v0.x の導入手順は、ざっくり以下のようなものでした。
 - **アップデート追随がだるい**：更新を取り込むたびに手作業を繰り返す
 - **`AGENTS.md` を二重管理しがち**：自プロジェクトの規約と River Review 由来の規約が混ざる
 
-「テンプレ配布」という形は、利用者が**自分用にカスタムする**前提では強い反面、**素直に最新を使いたい**人にとっては手間です。River Review のように「観点パッケージ」を提供する OSS では、後者のユースケースが多いことが見えてきました。
+OSS で「観点パッケージ」を提供するときは、**配布形式の選択そのものが利用体験を大きく左右する**——River Review のように「使う側がカスタムするより素直に最新を取りたい」ユースケースが多い OSS では、テンプレ配布は摩擦のほうが目立ちます。
 
 ## v1.x で踏み切ったこと
 
@@ -54,6 +54,8 @@ v1.x の方針はシンプルです。
 - **手作業のフォールバックは残す**：オフライン環境などのために、v0.x 相当のテンプレコピー手順は併存させる
 
 結果として、**導入は 3 ステップ**で済むようになりました。
+
+> 以下のコマンドは **River Review v1.2.1 時点で動作確認した手順**です。Claude Code のスラッシュコマンドと Codex のサブコマンドで CLI 構造が違うため、各ツールの最新ドキュメントもあわせて確認してください。
 
 ### Claude Code
 
@@ -79,8 +81,8 @@ codex plugin marketplace add s977043/river-review@v1.2.1  # バージョン pin 
 
 Plugin 化と聞くと「マニフェストファイルを書いて配布形式を変える」だけのように見えますが、River Review の v1.x で本当に意味があったのは **SSoT を移動したこと**でした。
 
-- v0.x: SSoT は **テンプレ群**（`templates/agent-workflow/codex/AGENTS.md` などのファイル一式）
-- v1.x: SSoT は **`.claude-plugin/marketplace.json`**
+- v0.x（Manual Era：テンプレ手配置時代）: SSoT は **テンプレ群**（`templates/agent-workflow/codex/AGENTS.md` などのファイル一式）
+- v1.x（Plugin Era：プラグイン配布時代）: SSoT は **`.claude-plugin/marketplace.json`**
 
 SSoT がマーケットプレイス定義に移動したことで、
 


### PR DESCRIPTION
## 概要
[#379](https://github.com/s977043/my-blog/pull/379) で生成した3ペルソナレビューに対し、**著者判断で「オススメ一括採用（#4/#6/#8/#9）」を実施**。下書き記事 `articles/river-review-plugin-migration.md`（`published: false` 維持）へ反映。

review-applier の自動判定は採用 0 件だったが、リスク低・改善価値が明確な 4 件を著者判断で採用。

## 採否一覧（10件）

### ✅ 採用 (4件)
| # | 該当 | 反映内容 |
|---|------|---------|
| 4 | L82-L83 | Manual Era / Plugin Era に日本語副題「テンプレ手配置時代 / プラグイン配布時代」を付与 |
| 6 | L46 段落 | 「テンプレ配布は手間」の重複表現を、「OSS で観点パッケージを提供するときの配布形式選択論」へ抽象化（次章の学びへの橋渡し） |
| 8 | L5 topics | `oss` → `marketplace` へ入れ替え（横断検索の導線強化） |
| 9 | L57 直後 | コマンド章冒頭に「**River Review v1.2.1 時点で動作確認した手順**」「Claude Code/Codex で CLI 構造が違う」の検証エビデンス 1 行追加 |

### ⏸ 保留 (6件) — 公開準備段階で再検討
| # | 該当 | 保留理由 |
|---|------|---------|
| 1 | L11-14 TL;DR 弾丸過多 | 文面再構成は編集判断 |
| 2 | L67-72 Codex pin コマンド統一 | `codex plugin reload` 等の存在を未検証で実装変更しない |
| 3 | L91 `.codex-plugin/` 前置き | 新規文面生成 |
| 5 | L136-154 学び章の構造変更 | 章単位の再構成は影響大 |
| 7 | L156-165 まとめキーフレーズ再掲 | 新規文面生成 |
| 10 | L24-28 `:::message` 役割変更 | 構成変更 + 新規文面 |

### ❌ 却下 (0件)
なし。

## 検証
- `npm run check` exit 0
- `check:zenn-title` OK（タイトル 70字以内）
- `check:internal-links` OK（90 files・リンク切れなし）
- `published: false` 維持（公開フラグ変更なし、`docs/publish-operating-policy.md` の著者ゲート対象外）

## 後続フロー
1. **本 PR** マージで採用分が main に反映
2. 公開準備段階で保留 6 件を再評価（必要なら追加 PR）
3. `published: true` 化 → 著者承認・別 PR
4. `release/zenn` sync PR → 著者承認・別 PR で Zenn deploy 発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)