### PR TITLE
chore(zenn): river-review-plugin-migration を published:true へ（main 段）

### DIFF
--- a/articles/river-review-plugin-migration.md
+++ b/articles/river-review-plugin-migration.md
@@ -3,7 +3,7 @@ title: "テンプレコピーをやめた — River Review を Claude Code / Cod
 emoji: "🔌"
 type: "tech"
 topics: ["claudecode", "codex", "marketplace", "プラグイン", "agentskills"]
-published: false
+published: true
 ---
 
 > TL;DR


### PR DESCRIPTION
## 概要
River Review Plugin 対応記事の公開（著者指示）。**main 段**。本 PR マージでは Zenn deploy は発火しない。

## 差分
`articles/river-review-plugin-migration.md`: `published: false → true`（1行）

## 公開フロー（2段・本PRは1段目）
1. **本 PR**: main へ published:true 化 → 承認・マージ
2. **次段**: `scripts/sync-release-zenn.sh` で release/zenn sync PR → 承認・マージ → Zenn deploy 発火

## rate-limit
過去24h `published:false→true` 切替 0件（`check:zenn-pace` OK・安全圏）

## レビュー収束
Round 1/2（#379-#382）で blocker 解消・採用10件中6件反映・nice-to-have 4件保留。

## 検証
- `npm run check` exit 0、単一フラグ差分のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)