### PR TITLE
docs(queue): River Review Plugin 記事の Zenn 公開を Done へ記録

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -26,6 +26,7 @@
 
 ## Done
 
+- 2026-06-05 zenn river-review-plugin-migration https://zenn.dev/minewo/articles/river-review-plugin-migration （River Review の Claude Code/Codex プラグイン対応記事。queue 外の新規執筆、GitHub README を情報源に構成。Round 1/2 レビュー収束〔PR #379-#382〕→ PR #383 main / PR #384 release/zenn でマージ→Zenn deploy 発火、公開反映確認済み）
 - 2026-06-04 note hermes-introduction-note https://note.com/mine_unilabo/n/nc1ac531190c9 （新規 note 公開、WXR インポート→手動公開。`articles_note/new/hermes-introduction-note.md` は編集の正本として残置、次回エクスポート取り込みで `published/nc1ac531190c9.md` が自動生成される）
 - 2026-06-04 zenn multi-agent-book-review-workflow https://zenn.dev/minewo/articles/multi-agent-book-review-workflow （queue #9。PR #372 main / PR #373 release/zenn でマージ→Zenn deploy 発火、多層AIレビュー収束済み）
 - 2026-06-02 qiita sdd-tdd-nonblocking-agent https://qiita.com/s977043/items/05934596111b9065465d （Zenn「仕様を揃えて止めない…3原則」cross-post、PR #353 改善反映、id:05934596111b9065465d）


### PR DESCRIPTION
## 概要
2026-06-05 に公開した River Review Plugin 対応記事を `docs/publish-queue.md` の Done に記録。

| 種別 | 記事 | URL |
|------|------|-----|
| 新規 publish（queue 外） | Zenn: river-review-plugin-migration | https://zenn.dev/minewo/articles/river-review-plugin-migration |

## 経緯
下書き(#378) → Round 1 レビュー(#379) → 採用4件(#380) → Round 2 レビュー(#381) → 採用6件(#382) → published:true(#383) → release/zenn(#384) → 公開反映確認（HTTP 200 / og:title）

## 検証
- `npm run check` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)