### PR TITLE
docs(ultracode): フロードキュメントを実装に同期（Links 条件付き / StaticScan grep+Read）

### DIFF
--- a/docs/ultracode-quality-check-flow.md
+++ b/docs/ultracode-quality-check-flow.md
@@ -25,9 +25,9 @@ flowchart TD
 
 | フェーズ | 何をするか | なぜ要るか |
 |---------|-----------|-----------|
-| **StaticScan** | 媒体固有の落とし穴を grep で静的検出（SVG 画像参照・相対リンク・frontmatter） | **文章レビューでは出ない媒体仕様バグ**を先回り（後述の学び①）|
+| **StaticScan** | 媒体固有の落とし穴を grep / Read で実ファイルから静的検出（SVG 画像参照・相対リンク・frontmatter。実際の行を引用）| **文章レビューでは出ない媒体仕様バグ**を先回り（後述の学び①）|
 | **Review** | 対象ごとに並列精読。実装の正本（コード/スキーマ/docs）と照合 | 事実誤り・読者を誤らせる記述を捕捉 |
-| **Links** | 外部リンクの実在/到達確認 | リンク切れ防止 |
+| **Links** | 外部リンクの実在/到達確認（**`args.links` を渡した時のみ実行**。未指定なら `brokenLinks` は常に 0）| リンク切れ防止 |
 | **Verify** | 各改善提案を「本当に価値があるか／水増しか」と**敵対的に判定**（既定は却下）| 過剰研磨の抑制（学び③）|
 | **Synthesize** | blocker / 確定改善 / リスクを構造化して返す | GO/NO-GO 判断材料 |
 | **（人手）実レンダリング** | Playwright 等で**実際の表示**を確認（mermaid 描画・cover・画像）| エージェントは描画結果を見ない（学び①）|
@@ -46,6 +46,8 @@ Workflow({ name: "ultracode-quality-check", args: {
 
 返り値の `summary.goNoGo` と `staticBlockers` / `blockers` / `brokenLinks` / `confirmedImprovements` を見る。
 `confirmedImprovements` だけを反映し、`rejectedImprovements` は**入れない**（水増し回避）。
+
+> `links` を渡さない場合 Links フェーズはスキップされ、`brokenLinks` は検証されず 0 のまま返る。外部リンクの実在確認が必要なときは `args.links` に URL 配列を明示的に渡す。
 
 ## このフローが捕まえた実例（PlanGate Book）
 


### PR DESCRIPTION
## 概要
ultracode 機能の追加・変更に伴うドキュメント整合確認の依頼に対し、ultracode 監査ワークフロー（実装/doc/参照を並列突合）を実行。**実装とドキュメントはほぼ整合**しており、乖離は軽微2件のみ。実装を正としてドキュメントを修正。

## 監査結果
- 実装（`.claude/workflows/ultracode-quality-check.js`）と doc（`docs/ultracode-quality-check-flow.md`）を全項目突合
- フロー名・5フェーズ構成・args（targets/implRepo/platform/links/claim）・返り値キー（summary.goNoGo / staticBlockers / blockers / brokenLinks / confirmedImprovements / rejectedImprovements）・運用方針（confirmedImprovements のみ反映）・限界記述 → **すべて整合、変更不要**

## 修正した乖離（2件）
| # | 乖離 | 修正 |
|---|------|------|
| 1 (medium) | Links は無条件フェーズのように記述されていたが、実装は `args.links` 指定時のみ実行（未指定なら `brokenLinks` 常に 0）| フェーズ表 + 返り値説明に条件付き実行を明示 |
| 2 (low) | StaticScan が「grep で検出」と書かれていたが実装は「grep / Read で実ファイルから検出」| フェーズ表を実装に合わせて修正 |

## 検証
- `npm run check` exit 0
- 差分は doc 1ファイル 4行のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)