### PR TITLE
feat(zenn): sync-release-zenn に公開影響プレビュー(ドライラン)を追加

### DIFF
--- a/scripts/sync-release-zenn.sh
+++ b/scripts/sync-release-zenn.sh
@@ -57,6 +57,16 @@ fi
 
 echo ""
 echo "[sync] OK: $BRANCH_NAME に main を反映済み"
+
+# 公開影響プレビュー（ドライラン）: この sync が release/zenn に新規に持ち込む publish 数を
+# diff モード（#393 で導入）で表示する。不可逆な公開の前に「何記事が公開されるか」を機械的に確認。
+# 非ブロッキング（STRICT 未指定＝表示のみ）。2 件以上なら WARN(FAIL相当) が出る。
+echo ""
+echo "[sync] ── 公開影響プレビュー（このsyncで新規公開される記事）──"
+BASE_REF=origin/release/zenn node scripts/check-zenn-publish-pace.js || true
+echo "[sync] ─────────────────────────────────────────────"
+
+echo ""
 echo "[sync] 次の手順:"
 echo "  git push -u origin $BRANCH_NAME"
 echo "  gh pr create --base release/zenn --title '$COMMIT_MSG'"


### PR DESCRIPTION
## 概要

残改善の最優先「ドライランモード」を実装。`sync-release-zenn.sh` の sync 完了時に **「このsyncで release/zenn に新規公開される記事と件数」** を自動表示する。今回の公開作業で私が手動 grep していた published 差分照合を、スクリプトに恒久化。

## 変更

- `scripts/sync-release-zenn.sh`: sync 完了後・push案内の前に、#393 で導入した **diffモード（`BASE_REF=origin/release/zenn`）** で公開影響プレビューを表示。
  - 非ブロッキング（`STRICT` 未指定＝表示のみ）。2件以上なら WARN(FAIL相当) を表示。
  - 実際のブロックは CI ゲート（#391/#393）が担う。本機能は **push/PR を作る前の事前確認（ドライラン）**。

## 効果

- 不可逆な公開操作の前に「何記事が公開されるか」を機械的に確認でき、二重公開を着手段階で気づける。
- #393 の diffモード資産を再利用（重複実装なし）。

## 検証

- `bash -n` 構文OK
- diffモードのロジックは #393 で動作確認済み（date非依存・FN/FP解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)