### PR TITLE
docs(qiita): DESIGN.md 導入ガイドを公開（queue #4）

### DIFF
--- a/Qiita/public/design-md-guide-and-adoption-log.md
+++ b/Qiita/public/design-md-guide-and-adoption-log.md
@@ -1,14 +1,14 @@
 ---
-title: "DESIGN.md 導入ガイド: AI実装のための入口・契約・検証をどう整えるか"
+title: 'DESIGN.md 導入ガイド: AI実装のための入口・契約・検証をどう整えるか'
 tags:
-  - AI駆動開発
-  - デザインシステム
-  - Penpot
-  - React
   - ドキュメント
+  - React
+  - デザインシステム
+  - AI駆動開発
+  - penpot
 private: false
-updated_at: '2026-06-10T06:08:18+09:00'
-id: null
+updated_at: '2026-06-10T06:16:49+09:00'
+id: 1ce6753867f4b166d74b
 organization_url_name: null
 slide: false
 ignorePublish: false

--- a/Qiita/public/design-md-guide-and-adoption-log.md
+++ b/Qiita/public/design-md-guide-and-adoption-log.md
@@ -6,22 +6,13 @@ tags:
   - Penpot
   - React
   - ドキュメント
-private: true
-updated_at: ''
+private: false
+updated_at: '2026-06-10T06:08:18+09:00'
 id: null
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開メモ（公開前に削除）:
-- 初期状態: private: true / ignorePublish: true（ローカル下書き）
-- Qiita へ限定共有: private: true / ignorePublish: false
-- 一般公開: private: false / ignorePublish: false
-- 公開当日に updated_at を更新し、本コメントを削除してから npm run check → publish:qiita
-- 元記事(Zenn): https://zenn.dev/minewo/articles/design-md-guide-and-adoption-log
--->
 
 ## TL;DR
 

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -13,7 +13,6 @@
 
 | # | 締切 | platform | path | レビュー | 状態 |
 |---|---|---|---|---|---|
-| 4 | **2026-06-09（火）18:00 JST** | qiita | `Qiita/public/design-md-guide-and-adoption-log.md` | Full（済 PR#285、予防反映済） | 未公開（ignorePublish:true）|
 | 5 | **2026-06-16（火）18:00 JST** | qiita | `Qiita/public/penpot-react-design-system-contract.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）|
 | 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
 - #7 (zenn-book) は **2026-06-01 公開完了**（下記 Done 参照）。本文・図・cover・5系統＋ultracode レビュー完了後、release/zenn PR #350 マージで go-live
@@ -26,6 +25,7 @@
 
 ## Done
 
+- 2026-06-10 qiita design-md-guide-and-adoption-log https://qiita.com/s977043/items/1ce6753867f4b166d74b （queue #4。Zenn「DESIGN.md 導入ガイド」cross-post、Full レビュー済 PR#285。id:1ce6753867f4b166d74b、締切 6/9 から 1 日遅れで公開）
 - 2026-06-05 zenn river-review-plugin-migration https://zenn.dev/minewo/articles/river-review-plugin-migration （River Review の Claude Code/Codex プラグイン対応記事。queue 外の新規執筆、GitHub README を情報源に構成。Round 1/2 レビュー収束〔PR #379-#382〕→ PR #383 main / PR #384 release/zenn でマージ→Zenn deploy 発火、公開反映確認済み）
 - 2026-06-04 note hermes-introduction-note https://note.com/mine_unilabo/n/nc1ac531190c9 （新規 note 公開、WXR インポート→手動公開。`articles_note/new/hermes-introduction-note.md` は編集の正本として残置、次回エクスポート取り込みで `published/nc1ac531190c9.md` が自動生成される）
 - 2026-06-04 zenn multi-agent-book-review-workflow https://zenn.dev/minewo/articles/multi-agent-book-review-workflow （queue #9。PR #372 main / PR #373 release/zenn でマージ→Zenn deploy 発火、多層AIレビュー収束済み）


### PR DESCRIPTION
## 概要

公開キュー #4「`design-md-guide-and-adoption-log`」を Qiita に公開した。

- 公開URL: https://qiita.com/s977043/items/1ce6753867f4b166d74b
- id: `1ce6753867f4b166d74b`
- Zenn 原典の cross-post（Full レビュー済 PR#285、予防反映済）

## 変更内容

- front matter を公開状態へ（`private`/`ignorePublish` を false、`updated_at` 更新、公開メモコメント削除）
- 公開時に qiita-cli が採番した `id` を反映
- `docs/publish-queue.md`: #4 を Queue から Done へ移動（公開日・URL記録）

## 検証

- `npm run check` EXIT=0（qiita-publish-hygiene OK / remote-cache OK）
- `npm run publish:qiita` → `Successful!`（公開済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)