### PR TITLE
docs(articles): flashフォールバックの的外れ指摘の知見をサルベージ

### DIFF
--- a/articles/ai-review-rate-limit-fallback.md
+++ b/articles/ai-review-rate-limit-fallback.md
@@ -98,7 +98,7 @@ flowchart LR
 
 - Gemini CLI は `429 You have exhausted your capacity on this model` で停止
 - 非対話実行では trusted-directory 系のエラーも発生
-- `flash` 系モデルに切り替えると動くが、所見が浅くなる
+- `flash` 系モデルに切り替えると動くが、所見が浅くなるだけでなく、存在しない記述への言及など的外れな指摘も混じる
 - Codex CLI も使用制限に到達
 - 結果として、手元の外部 CLI レビューが揃わない
 


### PR DESCRIPTION
## 概要

#401-403 の磨き込みのうち、現 main（#404版）に欠けていた検証済みの知見を1点サルベージする。

## 変更内容

L3 が `flash` 系モデルにフォールバックしたときの記述を補強:
- Before: 「所見が浅くなる」
- After: 「所見が浅くなるだけでなく、**存在しない記述への言及など的外れな指摘も混じる**」

これは過去の Gemini(L3)レビューで実際に観測した挙動（flash が記事に存在しない記述を指摘してきた）に基づく。

## 検証

- `npm run check` EXIT=0 / `published: false` 不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)