### PR TITLE
fix(check): FAQ coverage が :::details Q. 形式を誤検知する不具合を修正

### DIFF
--- a/scripts/check-article-faq-coverage.js
+++ b/scripts/check-article-faq-coverage.js
@@ -42,7 +42,8 @@ for (const file of files) {
   }
 
   // FAQ章を `## ...FAQ` または `## よくある質問` 見出しの直後〜次の `## ` 見出し直前で切り出し、
-  // その章内の `### Q.` のみをカウントする（章外散在の Q. を拾わないため）。
+  // その章内の Q&A をカウントする（章外散在の Q. を拾わないため）。
+  // 形式は2種を許容: `### Q.`（H3 見出し形式）と `:::details Q.`（Zenn アコーディオン形式）。
   const faqHeadingMatch = body.match(/^## .*(FAQ|よくある質問).*$/m);
   let qCount = 0;
   if (faqHeadingMatch) {
@@ -50,7 +51,8 @@ for (const file of files) {
     const restAfterHeading = body.slice(startIdx);
     const nextH2 = restAfterHeading.search(/^## /m);
     const faqSection = nextH2 === -1 ? restAfterHeading : restAfterHeading.slice(0, nextH2);
-    qCount = (faqSection.match(/^### Q\./gm) || []).length;
+    // `### Q.` または `:::details Q.`（全角「Q．」「Q：」も許容）を 1 問として数える。
+    qCount = (faqSection.match(/^(### |:::details )Q[.．:：]/gm) || []).length;
   }
   const hasFaq = !!faqHeadingMatch && qCount >= MIN_QA_FOR_FAQ;
 


### PR DESCRIPTION
## 概要

記事改善の棚卸し中に発見した `check:faq-coverage` の誤検知バグを修正。

## 問題

`scripts/check-article-faq-coverage.js` は FAQ の Q&A を `### Q.`（H3見出し形式）のみカウントしていた。Zenn の `:::details Q.`（アコーディオン形式）で FAQ を書いた記事を「Q&A 0 件」と誤判定していた。

実害例（いずれも 5 問の FAQ が実在）:
- `ai-review-rate-limit-fallback.md`
- `playwright-vs-chrome-devtools-e2e.md`

## 修正

FAQ 章内で `### Q.` と `:::details Q.` の両形式（全角 `Q．`/`Q：` 含む）をカウント。

## 検証

- 修正後、「見出しありだが Q&A 不足」の誤検知が 2件 → 0件
- `npm run check` EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)