### PR TITLE
docs(articles): codex移行記事のTOMLキー事実誤りを修正（developer_instructions）

### DIFF
--- a/articles/claude-code-to-codex-app-migration.md
+++ b/articles/claude-code-to-codex-app-migration.md
@@ -384,7 +384,9 @@ name = "security-reviewer"
 description = "Review authentication, authorization, and secret handling changes."
 
 # Example only. Check the exact supported keys in your Codex environment.
-instructions = """
+# （Codex の custom agents は instruction 本文を developer_instructions キーで持つ。
+#   キー名はバージョンで変わりうるので手元の ~/.codex/agents/*.toml で確認すること）
+developer_instructions = """
 You are a security reviewer.
 
 Focus on:


### PR DESCRIPTION
## 概要

記事改善の深掘りレビューで発見した**事実誤り**を修正。

`claude-code-to-codex-app-migration.md` の Custom agents TOML 例で、instruction 本文のキーを `instructions` と記載していたが、実際は **`developer_instructions`**。

## 裏取り

ローカルの実機 Codex agent 定義 `~/.codex/agents/*.toml` を確認。現行・旧 `.bak` とも一貫して `developer_instructions` を使用。`instructions` を使うファイルは存在しない。

## 変更

- TOML 例のキーを `developer_instructions` に修正＋実キー名の確認方法をコメント追記
- 既存のヘッジ文（「Example only / バージョンで変わりうる」）は維持

## rate-limit

公開済み記事の**更新**（`published: true` のまま、新規 publish トグルなし）。`check:zenn-pace` の publish 数には影響しない。

## 検証

`npm run check` EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)