### PR TITLE
docs(qiita): open-design-design-quality を公開（queue #6・cross-post）

### DIFF
--- a/Qiita/public/open-design-design-quality.md
+++ b/Qiita/public/open-design-design-quality.md
@@ -1,36 +1,22 @@
 ---
-title: "Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編"
+title: Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編
 tags:
-  - AI駆動開発
-  - デザインシステム
-  - Penpot
-  - OpenDesign
   - フロントエンド
-private: true
-updated_at: ''
-id: null
+  - デザインシステム
+  - AI駆動開発
+  - penpot
+  - OpenDesign
+private: false
+updated_at: '2026-06-22T09:39:38+09:00'
+id: af06444b664553ecdc8a
 organization_url_name: null
 slide: false
-ignorePublish: true
+ignorePublish: false
 ---
-
-<!--
-公開メモ（公開前に削除）:
-- 初期状態: private: true / ignorePublish: true（ローカル下書き）
-- Qiita へ限定共有: private: true / ignorePublish: false
-- 一般公開: private: false / ignorePublish: false
-- 公開当日に updated_at を更新し、本コメントを削除してから npm run check → publish:qiita
-- 元記事(Zenn): 2026-05-26 週公開予定 https://zenn.dev/minewo/articles/open-design-design-quality
-- Zenn 公開後: 下記の :::note info セクション（コメントアウト中）を有効化して原典リンクを追加
--->
-
-<!--
-Zenn 公開時に有効化する :::note info（壊れリンク回避のため Zenn 公開まで非表示）:
 
 :::note info
 本記事は、Zenn に掲載した [Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編](https://zenn.dev/minewo/articles/open-design-design-quality) を Qiita 向けに再構成したものです。
 :::
--->
 
 ## 想定読者
 

--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -11,9 +11,7 @@
 
 ## Queue（締切順）
 
-| # | 締切 | platform | path | レビュー | 状態 |
-|---|---|---|---|---|---|
-| 6 | **2026-06-23（火）18:00 JST** | qiita | `Qiita/public/open-design-design-quality.md` | Full（済 PR#286、予防反映済） | 未公開（ignorePublish:true）／**Zenn 公開（2026-05-26週）後に cross-post note 有効化必須**|
+（現在、公開待ちのキューは空。補充は手動で行を追加）
 - #7 (zenn-book) は **2026-06-01 公開完了**（下記 Done 参照）。本文・図・cover・5系統＋ultracode レビュー完了後、release/zenn PR #350 マージで go-live
 - #9 (zenn) は「Bookを多層AIレビューで作った話」。内容は収束済み・公開可。タイミングのみ分離（Book公開→update同期→新規publish の順で間隔を空ける）
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）
@@ -24,6 +22,7 @@
 
 ## Done
 
+- 2026-06-22 qiita open-design-design-quality https://qiita.com/s977043/items/af06444b664553ecdc8a （queue #6。Zenn「Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編」cross-post、Full レビュー済 PR#286。id:af06444b664553ecdc8a、締切 6/23 から 1 日前倒しで公開。ハイジーン（HTMLコメント削除／private:false・ignorePublish:false／cross-post `:::note info` 有効化）→ `npm run check` 全パス → `publish:qiita` → HTTP 200 反映確認済み）
 - 2026-06-15 qiita penpot-react-design-system-contract https://qiita.com/s977043/items/8c4802b14352d6412ea5 （queue #5。Zenn「PenpotとReactを同じ契約で運用するデザインシステムの作り方」cross-post、Full レビュー済 PR#286。id:8c4802b14352d6412ea5、締切 6/16 から 1 日前倒しで公開。ハイジーン（HTMLコメント削除／private:false・ignorePublish:false／updated_at）→ `npm run check` 全パス → `publish:qiita` → HTTP 200 反映確認済み）
 - 2026-06-11 zenn ai-review-rate-limit-fallback https://zenn.dev/minewo/articles/ai-review-rate-limit-fallback （queue 外の新規執筆。AIレビューをレート制限で止めない可用性多重化〔L1/L2/L3〕。多段磨き込み（実体験反映→3ペルソナ反復→Gemini L3レビュー→文章推敲→CI文脈除去→de-AI推敲＋3ペルソナ再レビュー）を経て公開。途中 #404 並列セッション衝突を調停。PR #413 main / #414 release/zenn でマージ→Zenn deploy 発火、HTTP 200 反映確認済み）
 - 2026-06-10 qiita design-md-guide-and-adoption-log https://qiita.com/s977043/items/1ce6753867f4b166d74b （queue #4。Zenn「DESIGN.md 導入ガイド」cross-post、Full レビュー済 PR#285。id:1ce6753867f4b166d74b、締切 6/9 から 1 日遅れで公開）


### PR DESCRIPTION
Qiita #6「Open Designでデザイン品質を上げる」を公開（cross-post）。

## 実施
- ハイジーン: HTMLコメント削除／`private:false`・`ignorePublish:false`／cross-post `:::note info` 有効化（Zenn原典は公開済み）
- `npm run check` 全パス（FAIL 0、qiita-publish-hygiene OK）
- `npm run publish:qiita -- open-design-design-quality` → `Posted ... af06444b664553ecdc8a` / Successful
- ライブ確認: https://qiita.com/s977043/items/af06444b664553ecdc8a → **HTTP 200**

## 反映
- 記事に `id` / `updated_at` 付与（qiita-cli）
- `docs/publish-queue.md`: #6 を Queue → Done に移動

締切 6/23 から1日前倒しで公開完了。
