### PR TITLE
feat(hooks): gh アカウント反転事故を防ぐ Claude Code PreToolUse hook を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hooks/claude-gh-account-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ git config core.hooksPath scripts/hooks
 1. 並列セッション衝突を回避するため `gh pr list --state open` で重複 PR がないか確認
 2. **DRAFT PR の存在確認** — `gh pr list --state open --search "is:draft"` で未完了の Codex / 並列セッション PR を把握（旧 PR の影響範囲を見落とさない）
 3. **`gh auth status` で active account を確認** — `git push` / `gh pr create` / `gh pr merge` の **直前すべて** で s977043 になっている必要あり（kominem-unilabo のままだと push は credential helper 設定次第で通るが PR 操作は `must be a collaborator` で失敗 → 切替 → 再実行の手戻り）。**特に `gh auth setup-git` を実行した直後は active account が切り替わる副作用がある** ため、その後の PR 操作前に必ず再確認。**手戻りを避けるには `npm run gh:ensure`（= `check-gh-account.sh --fix`）を push/PR 操作の直前に走らせると、想定外アカウント時に自動で s977043 へ切替してくれる**（2026-06-11: setup-git 後の反転が push/PR/merge ごとに 403 を起こした実績）
+   - **PreToolUse hook で自動ガード済み**: `.claude/settings.json` の PreToolUse hook（`scripts/hooks/claude-gh-account-guard.sh`）が `git push` / `gh pr create|merge|edit` / `gh api ...merge` の直前に `check-gh-account.sh --fix` を自動実行し、切替不能時のみブロックする（fail-open 設計）
 4. 対象ファイルがどのプラットフォームか確認（`@AGENTS.md` の配置規約表）
 5. `articles_note/published/` を触る場合は ⚠️ 規約を確認（`@AGENTS.md` 禁止事項）
 6. note 記事に画像を追加する場合: SVG → PNG 変換 → `articles_note/assets/` 配置 → **`file` でサイズ・寸法を確認**（プレースホルダ画像 <10KB を弾く） → main に先にマージ → WXR 生成の順序を守る。**WXR 生成は必ず `--base-url https://raw.githubusercontent.com/s977043/my-blog/main/articles_note/assets` を付ける**（未指定で画像参照が残ると `md_to_wxr.py` が exit 1 で失敗、意図的にローカル参照を残すなら `--allow-local-images`）

--- a/scripts/hooks/claude-gh-account-guard.sh
+++ b/scripts/hooks/claude-gh-account-guard.sh
@@ -22,6 +22,9 @@ set -u
 # jq が無い環境では解析できないので素通り
 command -v jq >/dev/null 2>&1 || exit 0
 
+# 手動実行・デバッグ時に stdin が TTY だと cat が入力待ちでハングするため素通り
+[ -t 0 ] && exit 0
+
 INPUT=$(cat 2>/dev/null) || exit 0
 [ -n "$INPUT" ] || exit 0
 
@@ -33,9 +36,12 @@ CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) |
 # 書き込み系のみ対象。gh pr list/view/checks 等の読み取り系は対象外。
 is_target() {
   local c="$1"
-  # git push（--no-verify 付き・`git -C <dir> push` 形式含む。
-  # pre-push hook のバイパス経路もカバーする）
-  if printf '%s' "$c" | grep -qE '(^|[;&|[:space:]])git([[:space:]]+-[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+push([[:space:]]|$)'; then
+  # git push（--no-verify 付き・`git -C <dir> push`・`git -c a="b c" push` のような
+  # スペース/クォート入りオプション形式も含む。pre-push hook のバイパス経路もカバーする）
+  # オプションを厳密にパースせず広めにマッチし、push ではない `git stash push` のみ除外
+  # （過剰マッチは check が走るだけで無害。すり抜け=undermatch の方が実害がある）
+  if printf '%s' "$c" | grep -qE '(^|[;&|[:space:]])git([[:space:]][^;&|]*)?[[:space:]]push([[:space:]]|$)' \
+     && ! printf '%s' "$c" | grep -qE '(^|[;&|[:space:]])git[[:space:]]+stash[[:space:]]+push([[:space:]]|$)'; then
     return 0
   fi
   # gh pr create / merge / edit

--- a/scripts/hooks/claude-gh-account-guard.sh
+++ b/scripts/hooks/claude-gh-account-guard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scripts/hooks/claude-gh-account-guard.sh
+# Claude Code PreToolUse hook（matcher: Bash）。
+# `gh auth setup-git` 後に gh active account が kominem-unilabo へ反転し、
+# git push / gh pr create / gh pr merge が 403 で失敗する事故（AGENT_LEARNINGS
+# 2026-04-30, 05-21, 06-11）を、書き込み系 gh/git 操作の直前に自動検知・自動切替で防ぐ。
+#
+# 挙動:
+# - stdin の hook JSON から tool_input.command を抽出
+# - 書き込み系コマンド（git push / gh pr create|merge|edit / gh api ...merge...）に
+#   マッチした場合のみ scripts/check-gh-account.sh --fix を実行
+# - 検証 OK（または自動切替成功）→ exit 0 で通す
+# - 切替不能 → exit 2 + stderr でブロック（Claude に理由が返る）
+# - ガード自体の前提が崩れている場合（jq 無し / JSON 不正 / check スクリプト不在 /
+#   リポジトリ外）は exit 0 で素通り = fail-open。ガードのバグで全 Bash が
+#   止まる事故を避けるため、ブロックは「検証が実行でき、かつ失敗した」時のみ。
+
+set -u
+
+# ---- fail-open ガード群 -------------------------------------------------
+
+# jq が無い環境では解析できないので素通り
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat 2>/dev/null) || exit 0
+[ -n "$INPUT" ] || exit 0
+
+# JSON 不正・command 欠落は素通り
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$CMD" ] || exit 0
+
+# ---- 対象コマンド判定 ---------------------------------------------------
+# 書き込み系のみ対象。gh pr list/view/checks 等の読み取り系は対象外。
+is_target() {
+  local c="$1"
+  # git push（--no-verify 付き・`git -C <dir> push` 形式含む。
+  # pre-push hook のバイパス経路もカバーする）
+  if printf '%s' "$c" | grep -qE '(^|[;&|[:space:]])git([[:space:]]+-[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+push([[:space:]]|$)'; then
+    return 0
+  fi
+  # gh pr create / merge / edit
+  if printf '%s' "$c" | grep -qE '(^|[;&|[:space:]])gh[[:space:]]+pr[[:space:]]+(create|merge|edit)([[:space:]]|$)'; then
+    return 0
+  fi
+  # gh api で merge を含むもの（REST/GraphQL 経由のマージ）
+  if printf '%s' "$c" | grep -qE '(^|[;&|[:space:]])gh[[:space:]]+api([[:space:]]|$)' \
+     && printf '%s' "$c" | grep -qi 'merge'; then
+    return 0
+  fi
+  return 1
+}
+
+is_target "$CMD" || exit 0
+
+# ---- 検証スクリプトの解決 -----------------------------------------------
+# テスト用に GH_GUARD_CHECK_SCRIPT で差し替え可能。
+# 通常は CLAUDE_PROJECT_DIR、無ければ本スクリプト位置から repo root を推定。
+if [ -n "${GH_GUARD_CHECK_SCRIPT:-}" ]; then
+  CHECK="$GH_GUARD_CHECK_SCRIPT"
+else
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    ROOT="$CLAUDE_PROJECT_DIR"
+  else
+    ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)" || exit 0
+  fi
+  CHECK="$ROOT/scripts/check-gh-account.sh"
+fi
+
+# リポジトリ外 / check スクリプト不在は素通り（fail-open）
+[ -f "$CHECK" ] || exit 0
+
+# ---- 検証実行 -------------------------------------------------------------
+if bash "$CHECK" --fix >&2; then
+  exit 0
+fi
+
+cat >&2 <<'EOM'
+[claude-gh-account-guard] ブロック: gh active account が期待アカウント s977043 でなく、自動切替（check-gh-account.sh --fix）にも失敗しました。
+このまま実行すると push 403 / "must be a collaborator" 失敗が発生します。
+復旧: gh auth switch -u s977043 を手動実行後、再試行してください。
+EOM
+exit 2

--- a/scripts/hooks/claude-gh-account-guard.test.sh
+++ b/scripts/hooks/claude-gh-account-guard.test.sh
@@ -60,6 +60,8 @@ assert "gh pr merge は検証対象"                           0 1 "$STUB_OK" "g
 assert "gh pr edit は検証対象"                            0 1 "$STUB_OK" "gh pr edit 123 --body x"
 assert "gh api + merge は検証対象"                        0 1 "$STUB_OK" "gh api repos/o/r/pulls/1/merge -X PUT"
 assert "複合コマンド中の git push も検証対象"             0 1 "$STUB_OK" "npm run check && git push -u origin feat/x"
+assert "スペース入りオプションの git push も検証対象"     0 1 "$STUB_OK" 'git -c user.name="My Name" push origin main'
+assert "git subtree push も検証対象"                      0 1 "$STUB_OK" "git subtree push --prefix=dist origin gh-pages"
 
 # --- 対象コマンドで検証失敗: exit 2 でブロック ---------------------------
 assert "検証失敗（切替不能）なら exit 2"                  2 1 "$STUB_NG" "git push origin main"

--- a/scripts/hooks/claude-gh-account-guard.test.sh
+++ b/scripts/hooks/claude-gh-account-guard.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# scripts/hooks/claude-gh-account-guard.test.sh
+# claude-gh-account-guard.sh のセルフテスト。
+# GH_GUARD_CHECK_SCRIPT でスタブ検証スクリプトに差し替え、実際の gh には触れない。
+# 実行: bash scripts/hooks/claude-gh-account-guard.test.sh
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/claude-gh-account-guard.sh"
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+PASS=0
+FAIL=0
+
+# スタブ: 呼ばれたことをマーカーファイルに記録し、STUB_EXIT で終了
+STUB_OK="$TMPDIR_T/stub_ok.sh"
+STUB_NG="$TMPDIR_T/stub_ng.sh"
+MARKER="$TMPDIR_T/called"
+cat > "$STUB_OK" <<EOF
+#!/usr/bin/env bash
+touch "$MARKER"
+exit 0
+EOF
+cat > "$STUB_NG" <<EOF
+#!/usr/bin/env bash
+touch "$MARKER"
+exit 1
+EOF
+chmod +x "$STUB_OK" "$STUB_NG"
+
+json_for() {
+  jq -n --arg cmd "$1" '{tool_name:"Bash", tool_input:{command:$cmd}}'
+}
+
+# assert <desc> <expected_exit> <expect_check_called(1|0)> <check_script> <command>
+assert() {
+  local desc="$1" want_exit="$2" want_called="$3" stub="$4" cmd="$5"
+  rm -f "$MARKER"
+  json_for "$cmd" | GH_GUARD_CHECK_SCRIPT="$stub" bash "$GUARD" >/dev/null 2>&1
+  local got=$?
+  local called=0
+  [ -f "$MARKER" ] && called=1
+  if [ "$got" = "$want_exit" ] && [ "$called" = "$want_called" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (exit: want=$want_exit got=$got / check-called: want=$want_called got=$called)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- 対象コマンド: 検証が走る -------------------------------------------
+assert "git push は検証対象（OK なら exit 0）"            0 1 "$STUB_OK" "git push origin main"
+assert "git push --no-verify も検証対象"                  0 1 "$STUB_OK" "git push --no-verify origin feat/x"
+assert "git -C <dir> push も検証対象"                     0 1 "$STUB_OK" "git -C /repo push -u origin feat/x"
+assert "gh pr create は検証対象"                          0 1 "$STUB_OK" "gh pr create --base main --title t"
+assert "gh pr merge は検証対象"                           0 1 "$STUB_OK" "gh pr merge 123 --squash --delete-branch"
+assert "gh pr edit は検証対象"                            0 1 "$STUB_OK" "gh pr edit 123 --body x"
+assert "gh api + merge は検証対象"                        0 1 "$STUB_OK" "gh api repos/o/r/pulls/1/merge -X PUT"
+assert "複合コマンド中の git push も検証対象"             0 1 "$STUB_OK" "npm run check && git push -u origin feat/x"
+
+# --- 対象コマンドで検証失敗: exit 2 でブロック ---------------------------
+assert "検証失敗（切替不能）なら exit 2"                  2 1 "$STUB_NG" "git push origin main"
+assert "gh pr merge も検証失敗なら exit 2"                2 1 "$STUB_NG" "gh pr merge 42 --squash"
+
+# --- 非対象コマンド: 検証は走らず exit 0 ----------------------------------
+assert "gh pr list は素通り"                              0 0 "$STUB_NG" "gh pr list --state open"
+assert "gh pr view は素通り"                              0 0 "$STUB_NG" "gh pr view 123 --json state"
+assert "gh pr checks は素通り"                            0 0 "$STUB_NG" "gh pr checks 123"
+assert "git status は素通り"                              0 0 "$STUB_NG" "git status --short"
+assert "merge を含む gh api 以外（git merge）は素通り"    0 0 "$STUB_NG" "git merge origin/main"
+assert "gh api の読み取り（merge 無し）は素通り"          0 0 "$STUB_NG" "gh api repos/o/r/pulls/1"
+assert "push を含む別コマンド（git stash push）は素通り"  0 0 "$STUB_NG" "git stash push -u -m sentinel"
+assert "クォート内文字列（echo 'git push ...'）は素通り"  0 0 "$STUB_NG" "echo 'git push origin main'"
+
+# --- fail-open 系 ----------------------------------------------------------
+rm -f "$MARKER"
+printf 'not-json' | GH_GUARD_CHECK_SCRIPT="$STUB_NG" bash "$GUARD" >/dev/null 2>&1
+if [ $? -eq 0 ] && [ ! -f "$MARKER" ]; then
+  echo "PASS: 不正 JSON は fail-open で exit 0"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: 不正 JSON は fail-open で exit 0"
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$MARKER"
+json_for "git push origin main" | GH_GUARD_CHECK_SCRIPT="$TMPDIR_T/no-such-script.sh" bash "$GUARD" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: check スクリプト不在は fail-open で exit 0"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: check スクリプト不在は fail-open で exit 0"
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$MARKER"
+printf '' | GH_GUARD_CHECK_SCRIPT="$STUB_NG" bash "$GUARD" >/dev/null 2>&1
+if [ $? -eq 0 ] && [ ! -f "$MARKER" ]; then
+  echo "PASS: 空 stdin は fail-open で exit 0"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: 空 stdin は fail-open で exit 0"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## 背景

`gh auth setup-git` 実行後に gh の active account が kominem-unilabo へ反転し、`git push` / `gh pr create` / `gh pr merge` が 403 / "must be a collaborator" で失敗する事故が **3回再発**している（AGENT_LEARNINGS.md **2026-04-30 / 2026-05-21 / 2026-06-11**）。

既存対策のカバレッジ:

| 対策 | カバー範囲 | 穴 |
|---|---|---|
| pre-push git hook | `git push` のみ | `gh pr create/merge/edit` は素通り |
| `npm run gh:ensure`（手動） | 任意 | 実行し忘れが事故原因そのもの |

## 実装内容

- **`scripts/hooks/claude-gh-account-guard.sh`** — Claude Code PreToolUse hook（matcher: Bash）
  - stdin の hook JSON から `jq -r '.tool_input.command // empty'` でコマンドを抽出
  - 検証対象: `git push`（`--no-verify` / `git -C <dir> push` 含む）、`gh pr create|merge|edit`、`gh api` かつ `merge` を含むもの。読み取り系（`gh pr list/view/checks`、`git stash push` 等）は対象外
  - マッチ時に `scripts/check-gh-account.sh --fix` を実行。自動切替成功なら exit 0、切替不能なら **exit 2** + stderr 日本語メッセージでブロック
  - **fail-open 設計**: jq 不在 / JSON 不正 / 空 stdin / check スクリプト不在（リポジトリ外）は exit 0 で素通り。ガード自体のバグで全 Bash が止まる事故を避けるため、ブロックは「検証が実行でき、かつ失敗した」時のみ
- **`.claude/settings.json`**（新規・プロジェクト共有設定として commit）— `hooks.PreToolUse` に matcher `Bash` で `"$CLAUDE_PROJECT_DIR"/scripts/hooks/claude-gh-account-guard.sh` を登録
- **`scripts/hooks/claude-gh-account-guard.test.sh`** — `GH_GUARD_CHECK_SCRIPT` 環境変数でスタブ検証スクリプトに差し替えるセルフテスト（実 gh に触れない）。check スクリプト新設時の初版バグ再発防止のため同梱
- **CLAUDE.md** — 作業開始時チェックリスト 3 に自動ガードの旨を追記（1行）

## テスト結果

```
bash scripts/hooks/claude-gh-account-guard.test.sh
RESULT: 21 passed, 0 failed
```

対象コマンド 8 件で検証実行、検証失敗時 exit 2、非対象コマンド 8 件で素通り、fail-open 3 件を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)