### PR TITLE
docs(publish-readiness): reviewState ラベルを Humanize ゲート統合後の実装に追従

### DIFF
--- a/docs/publish-readiness-gate-design.md
+++ b/docs/publish-readiness-gate-design.md
@@ -11,7 +11,7 @@
 
 - `finalBlocked`（must が残る＝公開不可）
 - `finalMustHigh` / `publishBlockers`（残件数）
-- `reviewState`（`post-improve-verified` / `post-improve-UNVERIFIED` / `no-improve-or-converged`）
+- `reviewState`（`post-humanize-verified` / `post-humanize-UNVERIFIED`。PR #459 の Humanize ゲート統合で旧 `post-improve-*` / `no-improve-or-converged` の3値から変更）
 
 しかし、これらは**ワークフロー実行時の返り値にしか存在せず、永続化されていない**。そのため公開オペレーション（`published: true` 化 → release/zenn sync）の時点で「この記事は公開可否レビューを通っているか / ブロッカーが残っていないか」を**機械的に判定できない**。
 


### PR DESCRIPTION
#459 で `reviewState` が `post-humanize-verified` / `post-humanize-UNVERIFIED` の2値に変わったため、設計書 `docs/publish-readiness-gate-design.md` の旧3値表記を実装に追従させる（1行のみ）。Codex外部レビュー時に検出した #459 の残課題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)