### PR TITLE
chore(qiita): #465 公開反映後のメタデータ同期（updated_at・タグ順正規化）

### DIFF
--- a/Qiita/public/ai-dev-team-2025-retrospective.md
+++ b/Qiita/public/ai-dev-team-2025-retrospective.md
@@ -1,12 +1,12 @@
 ---
 title: 2025年、AIコーディングエージェントをチーム開発に入れてわかったこと
 tags:
+  - AI駆動開発
   - アジャイル
   - チーム開発
   - 生成AI
-  - AI駆動開発
 private: false
-updated_at: '2026-04-27T00:29:32+09:00'
+updated_at: '2026-07-19T12:49:54+09:00'
 id: 0a43ef1991769fc07ae8
 organization_url_name: null
 slide: false

--- a/Qiita/public/ai-dev-team-reviewable-ai-changes.md
+++ b/Qiita/public/ai-dev-team-reviewable-ai-changes.md
@@ -1,12 +1,12 @@
 ---
 title: AIが書いたコードをレビュー可能にするために、先に決めておくこと
 tags:
-  - チーム開発
-  - コードレビュー
-  - 生成AI
   - AI駆動開発
+  - コードレビュー
+  - チーム開発
+  - 生成AI
 private: false
-updated_at: '2026-05-28T12:35:02+09:00'
+updated_at: '2026-07-19T12:50:31+09:00'
 id: 3ed2cb58d22ac41fe2e1
 organization_url_name: null
 slide: false

--- a/Qiita/public/ai-dev-team-small-issues-for-agents.md
+++ b/Qiita/public/ai-dev-team-small-issues-for-agents.md
@@ -1,12 +1,12 @@
 ---
 title: AIエージェントに任せるIssueは、小さく切るほどチーム開発で扱いやすかった
 tags:
+  - AI駆動開発
   - チーム開発
   - プロジェクト管理
   - 生成AI
-  - AI駆動開発
 private: false
-updated_at: '2026-05-19T07:49:52+09:00'
+updated_at: '2026-07-19T12:51:35+09:00'
 id: b13950837889d97479fc
 organization_url_name: null
 slide: false

--- a/Qiita/public/ai-dev-team-test-first-agent-workflow.md
+++ b/Qiita/public/ai-dev-team-test-first-agent-workflow.md
@@ -1,12 +1,12 @@
 ---
 title: AIに実装させる前にテスト観点を書くと、チーム開発がかなり安定した
 tags:
+  - AI駆動開発
   - TDD
   - テスト
   - 生成AI
-  - AI駆動開発
 private: false
-updated_at: '2026-05-28T12:16:01+09:00'
+updated_at: '2026-07-19T12:51:47+09:00'
 id: fd5e5642efb40bfe4198
 organization_url_name: null
 slide: false

--- a/Qiita/public/design-md-guide-and-adoption-log.md
+++ b/Qiita/public/design-md-guide-and-adoption-log.md
@@ -1,13 +1,13 @@
 ---
 title: 'DESIGN.md 導入ガイド: AI実装のための入口・契約・検証をどう整えるか'
 tags:
-  - ドキュメント
-  - React
-  - デザインシステム
   - AI駆動開発
+  - React
   - penpot
+  - デザインシステム
+  - ドキュメント
 private: false
-updated_at: '2026-06-10T06:16:49+09:00'
+updated_at: '2026-07-19T12:51:57+09:00'
 id: 1ce6753867f4b166d74b
 organization_url_name: null
 slide: false

--- a/Qiita/public/open-design-design-quality.md
+++ b/Qiita/public/open-design-design-quality.md
@@ -1,13 +1,13 @@
 ---
 title: Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編
 tags:
-  - フロントエンド
-  - デザインシステム
   - AI駆動開発
-  - penpot
   - OpenDesign
+  - penpot
+  - デザインシステム
+  - フロントエンド
 private: false
-updated_at: '2026-06-22T09:39:38+09:00'
+updated_at: '2026-07-19T12:52:33+09:00'
 id: af06444b664553ecdc8a
 organization_url_name: null
 slide: false

--- a/Qiita/public/penpot-react-design-system-contract.md
+++ b/Qiita/public/penpot-react-design-system-contract.md
@@ -1,13 +1,13 @@
 ---
 title: PenpotとReactを同じ契約で運用するデザインシステムの作り方
 tags:
-  - フロントエンド
-  - React
-  - デザインシステム
   - AI駆動開発
+  - React
   - penpot
+  - デザインシステム
+  - フロントエンド
 private: false
-updated_at: '2026-06-15T07:30:56+09:00'
+updated_at: '2026-07-19T12:52:15+09:00'
 id: 8c4802b14352d6412ea5
 organization_url_name: null
 slide: false


### PR DESCRIPTION
#465 の 7本を `publish:qiita` で Qiita へ反映した際、qiita-cli がサーバ正規化形式で working ファイルへ書き戻した **updated_at 更新とタグ順入れ替えのみ** を main へ同期する（本文差分なし、機械検証済み）。

- 全7本 HTTP 200 確認済み
- `check:qiita-drift`: drift なし (checked 20 / skip 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)