### PR TITLE
chore(qiita): #469 公開反映後のメタデータ同期（updated_at・タグ順正規化）

### DIFF
--- a/Qiita/public/5a4665e78c4bd1a5c1bc.md
+++ b/Qiita/public/5a4665e78c4bd1a5c1bc.md
@@ -1,13 +1,13 @@
 ---
 title: AIコードレビューはPRだけ見ていていいのか？ 開発の流れ全体をレビューするOSS「River Review」を作った
 tags:
-  - 開発プロセス
   - AI
+  - GitHubActions
   - OSS
   - コードレビュー
-  - GitHubActions
+  - 開発プロセス
 private: false
-updated_at: '2026-06-03T09:32:45+09:00'
+updated_at: '2026-07-19T19:59:49+09:00'
 id: 5a4665e78c4bd1a5c1bc
 organization_url_name: null
 slide: false

--- a/Qiita/public/design-md-guide-and-adoption-log.md
+++ b/Qiita/public/design-md-guide-and-adoption-log.md
@@ -7,7 +7,7 @@ tags:
   - デザインシステム
   - ドキュメント
 private: false
-updated_at: '2026-07-19T12:51:57+09:00'
+updated_at: '2026-07-19T19:59:43+09:00'
 id: 1ce6753867f4b166d74b
 organization_url_name: null
 slide: false

--- a/Qiita/public/open-design-design-quality.md
+++ b/Qiita/public/open-design-design-quality.md
@@ -7,7 +7,7 @@ tags:
   - デザインシステム
   - フロントエンド
 private: false
-updated_at: '2026-07-19T12:52:33+09:00'
+updated_at: '2026-07-19T19:59:25+09:00'
 id: af06444b664553ecdc8a
 organization_url_name: null
 slide: false

--- a/Qiita/public/penpot-react-design-system-contract.md
+++ b/Qiita/public/penpot-react-design-system-contract.md
@@ -7,7 +7,7 @@ tags:
   - デザインシステム
   - フロントエンド
 private: false
-updated_at: '2026-07-19T12:52:15+09:00'
+updated_at: '2026-07-19T19:59:35+09:00'
 id: 8c4802b14352d6412ea5
 organization_url_name: null
 slide: false


### PR DESCRIPTION
#469 の4本を `publish:qiita` で反映した際の qiita-cli 書き戻し（updated_at・タグ順のみ、本文差分なし）を main へ同期。全4本 HTTP 200 確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)