### PR TITLE
chore(qiita): #472 公開反映後のメタデータ同期（updated_at・タグ順正規化）

### DIFF
--- a/Qiita/public/5a4665e78c4bd1a5c1bc.md
+++ b/Qiita/public/5a4665e78c4bd1a5c1bc.md
@@ -7,7 +7,7 @@ tags:
   - コードレビュー
   - 開発プロセス
 private: false
-updated_at: '2026-07-19T19:59:49+09:00'
+updated_at: '2026-07-19T20:21:41+09:00'
 id: 5a4665e78c4bd1a5c1bc
 organization_url_name: null
 slide: false

--- a/Qiita/public/5ebff79112ecf1af872c.md
+++ b/Qiita/public/5ebff79112ecf1af872c.md
@@ -1,13 +1,13 @@
 ---
 title: AIの止まり方を「数字で見る」ようにした体験：PlanGate v8.6.0でMetrics v1とGovernanceを入れた話
 tags:
-  - チーム開発
-  - コードレビュー
-  - 生成AI
   - AI駆動開発
   - ClaudeCode
+  - コードレビュー
+  - チーム開発
+  - 生成AI
 private: false
-updated_at: '2026-05-28T12:34:52+09:00'
+updated_at: '2026-07-19T20:21:25+09:00'
 id: 5ebff79112ecf1af872c
 organization_url_name: null
 slide: false

--- a/Qiita/public/plangate-ai-coding-workflow.md
+++ b/Qiita/public/plangate-ai-coding-workflow.md
@@ -1,13 +1,13 @@
 ---
 title: 'アジャイルでAI駆動開発をどう回すか: PlanGateの考え方とテンプレート'
 tags:
+  - AI駆動開発
+  - ClaudeCode
   - TDD
   - アジャイル
   - スクラム
-  - AI駆動開発
-  - ClaudeCode
 private: false
-updated_at: '2026-05-28T12:14:06+09:00'
+updated_at: '2026-07-19T20:21:14+09:00'
 id: 6041bbc2659412341d54
 organization_url_name: null
 slide: false

--- a/Qiita/public/river-reviewer-agent-skills.md
+++ b/Qiita/public/river-reviewer-agent-skills.md
@@ -1,13 +1,13 @@
 ---
 title: プロンプトを磨くのをやめた：チームのレビュー知識を Agent Skills に変える River Review 体験
 tags:
+  - AI駆動開発
+  - GitHubActions
   - OSS
   - コードレビュー
-  - GitHubActions
   - 生成AI
-  - AI駆動開発
 private: false
-updated_at: '2026-06-03T09:32:45+09:00'
+updated_at: '2026-07-19T20:21:30+09:00'
 id: 607d78c35745b17f9bc8
 organization_url_name: null
 slide: false


### PR DESCRIPTION
#472 の4本を publish:qiita で反映した際の qiita-cli 書き戻し（updated_at・タグ順のみ、本文差分なし）。全4本 HTTP 200 確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)