### PR TITLE
docs(queue): ai-agent-self-improvement-loop-design の Zenn 公開を Done 記録

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -22,6 +22,7 @@
 
 ## Done
 
+- 2026-07-20 zenn ai-agent-self-improvement-loop-design https://zenn.dev/minewo/articles/ai-agent-self-improvement-loop-design （queue 外の新規執筆。AIエージェントの自己改善を記録・棚卸し・機械化・剪定の4機能として設計。全面改稿→3ペルソナ×最大3ループ→Humanize〔論証観点T11〜T15〕→Codex外部レビュー2回で磨き込み。Loop1 が Skills 切り詰め仕様の事実誤りを検出〔セルフ/Codex 見落とし〕→公式仕様と自環境観測を分離。flip PR #484 main / sync PR #486 release/zenn でマージ→Zenn deploy 発火。デプロイ時に Zenn 側で「リポジトリの参照でエラー」バナーが出たが 1ファイル更新は反映され HTTP 200 / API 出現確認済み〔published_at 09:34 JST〕）
 - 2026-06-22 qiita open-design-design-quality https://qiita.com/s977043/items/af06444b664553ecdc8a （queue #6。Zenn「Open Designでデザイン品質を上げる：Penpot契約運用とDESIGN.mdの続編」cross-post、Full レビュー済 PR#286。id:af06444b664553ecdc8a、締切 6/23 から 1 日前倒しで公開。ハイジーン（HTMLコメント削除／private:false・ignorePublish:false／cross-post `:::note info` 有効化）→ `npm run check` 全パス → `publish:qiita` → HTTP 200 反映確認済み）
 - 2026-06-15 qiita penpot-react-design-system-contract https://qiita.com/s977043/items/8c4802b14352d6412ea5 （queue #5。Zenn「PenpotとReactを同じ契約で運用するデザインシステムの作り方」cross-post、Full レビュー済 PR#286。id:8c4802b14352d6412ea5、締切 6/16 から 1 日前倒しで公開。ハイジーン（HTMLコメント削除／private:false・ignorePublish:false／updated_at）→ `npm run check` 全パス → `publish:qiita` → HTTP 200 反映確認済み）
 - 2026-06-11 zenn ai-review-rate-limit-fallback https://zenn.dev/minewo/articles/ai-review-rate-limit-fallback （queue 外の新規執筆。AIレビューをレート制限で止めない可用性多重化〔L1/L2/L3〕。多段磨き込み（実体験反映→3ペルソナ反復→Gemini L3レビュー→文章推敲→CI文脈除去→de-AI推敲＋3ペルソナ再レビュー）を経て公開。途中 #404 並列セッション衝突を調停。PR #413 main / #414 release/zenn でマージ→Zenn deploy 発火、HTTP 200 反映確認済み）


### PR DESCRIPTION
## 概要

Zenn 記事「AIエージェントを勝手に成長させない — 記録・棚卸し・機械化・剪定の自己改善ループ」の公開完了を `docs/publish-queue.md` の Done セクションへ記録（公開フロー フェーズ3）。

## 公開実績

- **公開日時**: 2026-07-20 09:34 JST（Zenn API published_at）
- **URL**: https://zenn.dev/minewo/articles/ai-agent-self-improvement-loop-design （HTTP 200・API 出現確認済み）
- **PR チェーン**: flip #484（main 段）→ sync #486（release/zenn・deploy 発火）
- **注記**: デプロイ時に Zenn ダッシュボードで「リポジトリの参照でエラー」バナーが表示されたが、1ファイル更新の反映自体は成功（表示上の transient エラー）

## 検証

- `npm run check` exit 0
- 差分は Done 行1行の追記のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)