### PR TITLE
docs(articles): #495改稿版の再レビュー + GitHub権限主張の一次検証

### DIFF
--- a/articles/ai-merge-ready-state-machine.md
+++ b/articles/ai-merge-ready-state-machine.md
@@ -2,7 +2,7 @@
 title: "AIにマージさせない。PRをMERGE_READYまで運ぶ状態機械の設計"
 emoji: "🔀"
 type: "tech"
-topics: ["ai駆動開発", "aiagent", "github", "設計", "自動化"]
+topics: ["ai駆動開発", "aiagent", "github", "生成ai", "codereview"]
 published: false
 ---
 
@@ -12,7 +12,7 @@ CIが失敗したら原因を調べて修正する。レビューで指摘され
 
 では、すべてのチェックを通過した後、そのPRをマージするところまでAIに任せるべきでしょうか。
 
-私が開発しているPlanGateでは、次の境界を置きました。
+PlanGateでは、次の境界を置きました。
 
 > **PRをマージ可能な状態まで収束させるのは自動化する。  
 > ただし、マージするかを判断し、実際にマージするのは人間に残す。**
@@ -85,6 +85,7 @@ PlanGate全体では、Deliveryの状態として `PR_CREATED`、`MERGE_READY`�
 
 | 種別 | 状態 / exit | 意味 |
 |---|---|---|
+| 入口 | `PR_CREATED` | AIが担当を開始する起点 |
 | 中間 | `WAITING_FOR_CHECKS` | 最新コミットのCI結果を待っている |
 | 中間 | `WAITING_FOR_REVIEW` | 最新コミットに対するレビューを待っている |
 | 中間 | `CHECKS_FAILED` | CIが失敗し、修正が必要 |
@@ -94,6 +95,7 @@ PlanGate全体では、Deliveryの状態として `PR_CREATED`、`MERGE_READY`�
 | 終端 | `MERGE_READY` | 機械ゲートを通過し、人間の最終判断を待つ |
 | exit | `HUMAN_ESCALATED` | 検証不能、上限超過、不可逆操作などを人間へ返す |
 | exit | `EXEC_RETURN` | 計画外の変更を実行工程へ差し戻す |
+| exit | `ERROR` / `STOP` | snapshotの必須フィールド欠落など、判定入力自体が不正で評価を続行できない |
 
 実装では、正常終了地点を `MERGE_READY` と定義し、そこから先の遷移を空にしています。
 
@@ -147,10 +149,12 @@ flowchart LR
 
 1. AIがPRを作成し、最新のhead SHAを含むsnapshot（判定入力）を作る
 2. CI失敗を検出して `CHECKS_FAILED` へ進み、修正actionを要求する
-3. AIが修正をpushするとhead SHAが変わり、古いCI結果とレビュー承認をstaleとして除外する
+3. AIが修正をpushするとhead SHAが変わり、古いCI結果とレビュー承認をstale（古くなって現在のコードに対応しない状態）として除外する
 4. 新しいheadへのCIとレビューを再評価し、未解決の指摘があれば `REVIEW_REPAIR` へ戻す
 5. 指摘への対応記録が揃った後、`MERGE_READY_CANDIDATE` で完了条件を再評価する
 6. 条件を満たしたら `MERGE_READY` recordを残し、人間へ最終判断を渡す
+
+`MERGE_READY_CANDIDATE` を独立した状態として挟むのは、全ゲート通過の判定と、head SHAが評価の途中で更新されていないか等の再確認を分けるためです。評価中に新しいコミットが入った場合の取りこぼしを防ぐよう、確定前にもう一度だけ完了条件を照合します。
 
 この流れでは、AIは失敗を修正して前進できますが、古い証跡を使い回せず、最終的なマージにも進めません。
 
@@ -218,7 +222,7 @@ GitHubにも、新しいコミットがpushされたときに古い承認を却�
 
 PlanGateでは、不確実な入力を優先的に評価し、人間へ返します。概念的には次の順序です。
 
-```text
+```python
 # 疑似コード: 評価順序を示す（真偽値フラグや定数returnは実装名ではない）
 if snapshot_is_invalid:
     stop_with_error()
@@ -300,13 +304,13 @@ gh pr merge 123
 
 これは**責務境界**であり、それだけで強制的な**権限境界**になるわけではありません。AIが利用する認証情報にマージ権限が残っていれば、標準経路の外から越境できる余地は残ります。
 
-GitHubのfine-grained tokenでは、操作ごとに必要な権限が異なります。たとえば、PRレビューやレビューコメントの作成には `Pull requests: write`、REST APIによるPRマージには `Contents: write` が必要です。
+GitHubのfine-grained tokenでは、操作ごとに必要な権限が異なります。たとえば、PRレビューやレビューコメントの作成には `Pull requests: write`、REST APIによるPRマージには `Contents: write` が必要です（各エンドポイントの必要権限は[GitHub REST API公式リファレンス](https://docs.github.com/en/rest/pulls)の各「Fine-grained access tokens for this endpoint」節に記載があります）。
 
 一方、AIにPR headへのpushを許可する認証情報は、リポジトリ内容への書き込み能力を持ちます。REST APIによるマージにも `Contents: write` が必要なため、同じ認証情報のまま「pushは許可するが、マージは禁止する」という境界をトークンスコープだけで作るのは困難です。
 
 そのため、単一の防御で完全性を主張するのではなく、標準実行経路のallowlistに加え、GitHubの実行主体や権限の分離、ruleset、required review、branch protection、人間が所有する最終操作を組み合わせます。
 
-なお、**2026年8月2日時点**のPlanGateリポジトリでは、required approving reviewを防衛線としてまだ利用していません。この記事で説明している中心的な境界は、状態機械、標準実行経路のallowlist、人間による最終確認です。
+なお、**本記事執筆時点（2026年8月）**のPlanGateリポジトリでは、required approving reviewを防衛線としてまだ利用していません（今後追加する可能性があります）。この記事で説明している中心的な境界は、状態機械、標準実行経路のallowlist、人間による最終確認です。
 
 ## 判定と外部作用を分離する
 
@@ -384,7 +388,7 @@ receipt
 
 ## 実装から得た3つの設計原則
 
-ここまでの各章を、PlanGate固有の状態名やファイル構成を外して一般原則へ畳むと、今回の設計は次の3原則に整理できます。
+ここまでの各章を、PlanGate固有の状態名やファイル構成を外して一般原則へ畳むと、今回の設計は次の3原則に整理できます（原則を一般化した形。次章はこの原則を自リポジトリへ導入するときのチェックリストです）。
 
 ### 1. 「禁止する」より「経路を持たない」
 
@@ -419,7 +423,7 @@ receipt
 
 ## 自分の環境へ転用するときの確認項目
 
-同じ考え方を自分のリポジトリへ導入するときは、次を確認します。
+前章の3原則を実際の作業手順へ落とすと、自分のリポジトリへ導入するときは次を確認します。
 
 - AIが担当する状態機械の正常終了地点を定義したか
 - `MERGED` に相当する不可逆操作が、AI側の遷移やコマンドに残っていないか

--- a/reviews/zenn/ai-merge-ready-state-machine.md
+++ b/reviews/zenn/ai-merge-ready-state-machine.md
@@ -1,176 +1,73 @@
-<!-- publish-readiness: blocked=false mustHigh=0 verified=true articleHash=460151a2e13b651a27a8555ae38633bb0a1bf838 loops=4 reviewedAt=2026-08-02T02:28:00Z -->
+<!-- publish-readiness: blocked=false mustHigh=0 verified=true articleHash=b377f51222f63d90400bb56a6c64d4d1e77d1b0f loops=2 reviewedAt=2026-08-02T03:00:03Z -->
 
 # レビュー成果物: ai-merge-ready-state-machine
 
-- **対象記事**: `articles/ai-merge-ready-state-machine.md`
-- **実施日**: 2026-08-02
-- **改善ループ数**: 4（初回3ループ＋マージ後の最終レビュー1回）
-- **レビュー視点**: director（論旨・読者価値）/ editor（構成・文章）/ engineer（実装整合）/ security（脅威モデル・過大保証）
-- **レビュー状態**: マージ後レビューの指摘反映済み
-- **総合判定**: 公開可能（must/high なし、`published: false` 維持）
+- 対象記事: `articles/ai-merge-ready-state-machine.md`
+- 改善ループ数: **2**（最大 3）
+- レビュー状態: **post-humanize-verified**
+- 総合判定: **公開可（must/high ゼロ・収束）**。残課題はすべて low の任意ポリッシュ。
+
+> 注記: Humanize は Phase 1 の review-only です。Humanize の指摘だけを理由に本文を変更したり、公開ブロッカーへ昇格させたりしません。
 
 ---
 
-## 1. 不変条件
+## 1. 改善ループの要約
 
-### 中心主張
-
-PRを `MERGE_READY` まで収束させる処理はAIへ任せるが、マージの判断と実行は人間へ残す。その境界を、自然言語の禁止事項だけでなく、状態機械・fail-closed・外部作用境界・再開可能な記録によって構造化する。
-
-### 保持した強調点
-
-1. `MERGE_READY` は「マージしてよい」ではなく、人間の最終判断へ載せられる状態
-2. AIが担当する内部状態機械に `MERGED` への遷移を置かない
-3. 最新head SHAにCI・レビュー・証跡を束縛し、staleな結果を使わない
-4. 検証不能な入力を成功扱いせず、人間へエスカレーションする
-5. 外部作用をallowlistへ集約する
-6. allowlistと静的検査は完全なsandboxではない
-7. 責務境界と権限境界は別物
-8. 判定と外部作用を分離する
-9. intent／receiptだけでは厳密なexactly-onceを保証しない
-10. 自律性の設計では「どこで止まるか」を決める
-
-### 変更していないもの
-
-- Front Matterの `published: false`
-- 記事タイトルと中心メッセージ
-- PlanGate実装への参照リンク
-- 一人称のです・ます調
+| ループ | 指摘件数 | must-high | 反映件数 | 主張保持 | converged | 概要 |
+|:---:|:---:|:---:|:---:|:---:|:---:|---|
+| Loop 1 | 6 | 1 | 6 | 保持 | false | 「価値の先出し→設計→限界」の構成が明快。high 1件は強調点7（トークンスコープでpush許可/merge禁止の境界は作れない）を支える GitHub 権限記述への一次出典付与（WebFetch で公式表を確認できず未検証のため著者確認推奨）。他は stale 初出補足・終盤3セクションの役割明示・疑似コード言語指定・状態表の入口行・日付表記の陳腐化対策など medium/low。 |
+| Loop 2 | 5 | 0 | 4 | 保持 | false | Loop1 反映後、主張・7強調点・章立て骨格・published:false を保ったまま高完成度。トークン権限主張は公式リンク付きで据え置き（未検証扱い）。最も価値ある指摘は MERGE_READY_CANDIDATE の存在理由が薄い点（medium, clarity）で疑似コードの completion_needs_recheck 分岐と接続する一文で解消。他は終盤箇条書き重複・PlanGate 自己紹介重複・stop_with_error() の状態表非対称・topics 汎用語（すべて low, touchesClaim 全件 false）。 |
+| Verify | 3 | 0 | 0 | — | **true** | 最終確認レビュー。8つの強調点すべて維持、主張の方向・希釈・反転なし。です・ます丁寧体、一人称「筆者」、括弧補足の語り口、章立て、published:false すべて保護。新規の事実誤りなし。残る3件は low の任意ポリッシュのみ。**収束と判断。** |
 
 ---
 
-## 2. Loop 1: 技術整合性と境界の定義
+## 2. Humanize 結果（Phase 1 / review-only）
 
-### レビュー結果
+- **passed: true**
+- 件数: **low 2 / medium 0 / high 0**
+- high 指摘・保護領域への変更提案なし。主張・強調点（MERGE_READY と実マージの分離、経路を持たない設計、fail-closed、head SHA 束縛、allowlist 集約、責務境界の限界の正直な明示 ほか）はすべて保持。
+- コード・表・mermaid・数値・バージョン・URL・PlanGate 用語・筆者の経験には指摘なし。
 
-| ID | 視点 | 優先度 | 指摘 |
-|---|---|---|---|
-| L1-01 | engineer | high | 状態表とMermaid図が `MERGE_READY_CANDIDATE`、`HUMAN_ESCALATED`、`EXEC_RETURN` を省略し、本文の状態機械説明と不一致 |
-| L1-02 | security | high | 「AIにマージさせない」が、ワークフロー上の責務境界なのか、認証・権限による強制境界なのか曖昧 |
-| L1-03 | director | medium | 導入直後に `:::message` が2つ連続し、予告内容が重複 |
-| L1-04 | editor | medium | マージ判断の例で「リリース」と「ブランチへの取り込み」が混在 |
-| L1-05 | engineer | medium | `MERGE_READY` で人間へ何を引き渡すのかが抽象的 |
-| L1-06 | editor | low | `MERGE_READY_CANDIDATE` の表説明が長く、一覧性が低い |
-| L1-07 | engineer | low | Mermaidの人間領域ノード宣言順を堅牢化できる |
+### 全 findings
 
-### 反映内容
+| id | pattern | layer | risk | 保護領域 | 著者入力 | location | 指摘 / 修正案 |
+|---|---|---|:---:|:---:|:---:|---|---|
+| H-001 | S12-recurring-importance-closer | style | low | false | 不要 | 各章の締め（「不確実性は成功ではなく〜」冒頭 / 「intentとreceiptで〜」末尾 / 設計原則2 / 設計原則3） | 複数章が「〜が重要です／重要になります」で締められ締めの語彙が単調。4か所のうち2か所程度を、その章固有の帰結を述べる文末（例:「〜を分ける効果がここにある」「〜が破綻の分岐点になる」など主張を変えない言い換え）に変え語彙を分散。 |
+| H-002 | S10-list-intro-template | style | low | false | 不要 | 「修正後の古い承認を使わない」導入部 / 「不確実性は成功ではなく〜」導入部 / 「外部作用はallowlistへ閉じ込める」中盤 | 箇条書き直前導入が「たとえば、次の〜です。」の同一鋳型で反復。1〜2か所を直前文からリストへ直結する形（例:「典型的にはこの順で進む」「起こり得るのはこうした状態だ」）に置換。内容・順序・項目は不変。 |
 
-- 状態表に中間状態・終端・2つのexitを追加
-- Mermaid図へ `MERGE_READY_CANDIDATE`、`HUMAN_ESCALATED`、`EXEC_RETURN` を追加
-- 人間領域をsubgraphとして先に定義し、AI状態機械外への破線遷移を明示
-- 導入の2つのメッセージを1つへ統合
-- マージ判断とリリース判断の混同を修正
-- `MERGE_READY` recordの6フィールドを追加
-- 「責務境界であり、権限境界ではない」という説明を追加
-
-### 判定
-
-中心主張は保持。状態機械の説明と図の不一致、境界の過大解釈につながる箇所を解消した。
+**著者入力が必要な項目: なし**（両件とも requiresAuthorInput=false、意味を変えない局所修正で対応可能）。
 
 ---
 
-## 3. Loop 2: 読者理解と保証範囲
+## 3. 最終レビュー 全 findings
 
-### レビュー結果
+overallVerdict: **収束（converged=true）**。8つの強調点はすべて維持、主張の反転・希釈なし。文体・語り口・章立て・published:false の保護領域は不可侵。must/high はゼロ。残る3件は low の任意ポリッシュで公開ブロッカーではない。外部主張（fine-grained token の Contents: write / Pull requests: write）も出典付きで妥当、「執筆時点（2026年8月）」の限定表現も現在日付と整合。
 
-| ID | 視点 | 優先度 | 指摘 |
-|---|---|---|---|
-| L2-01 | engineer | high | `MERGE_READY` recordが「最終判断に必要な情報をすべて保証する」と読める。実装は記録の存在までで、根拠内容の妥当性は人間の責務 |
-| L2-02 | director | medium | 状態名の説明だけでは、1本のPRがどう進むか想像しにくい |
-| L2-03 | security | medium | 許可するpushが一般的な `git push` に読め、forceや削除を組み立てない実装境界が伝わりにくい |
-| L2-04 | editor | medium | allowlist、snapshot、intent、receiptの初出説明が不足 |
-| L2-05 | engineer | medium | intentあり・receiptなしの扱いを「未完了」と断定すると、外部作用成功後・receipt前中断の不確実性が薄れる |
-| L2-06 | editor | low | 1文段落と定型的な対比表現が続く箇所がある |
+| id | persona | priority | location | touchesClaim | title / suggestion |
+|---|---|:---:|:---:|:---:|---|
+| eng-token-source-link-precision | engineer | low | L307 | false | **トークン権限の出典リンクをエンドポイント別アンカーへ精緻化**。現状リンクは一般ランディング `https://docs.github.com/en/rest/pulls` で該当節に直接到達しない。強調点7はそのまま、検証容易性向上のためマージ側を `.../rest/pulls/pulls#merge-a-pull-request`、レビュー作成側を `.../rest/pulls/reviews#create-a-review-for-a-pull-request` に分割。文面（Contents: write / Pull requests: write の対比）は変更不要。 |
+| editor-failclosed-term-order | editor | low | L33 | false | **fail-closed の初出（messageボックス）に最小補足があると親切**。括弧定義は L255 まで出ない。予告リストなので現状も許容だが、L33 を「fail-closed（検証できない状態を成功扱いしない設計）、allowlist、intent／receiptの設計」のように一語補える。主張・語調・順序は不変。 |
+| director-mermaid-b-loop-legibility | director | low | L110-L138 | false | **mermaid 図の中央評価ノード B へ戻る多重ループの読み取り負荷**。中間状態（C/E/M）と修正後 H が評価ノード B へ戻り初見で再評価ループの向きが追いにくい。骨格・状態名は変えず B ラベルを「最新headを再評価」に統一し、`M -->|再照合OK| B` のようにエッジへ短い語を添える。構成・主張は不変。 |
 
-### 反映内容
-
-- 「1本のPRがMERGE_READYへ進むまで」を追加し、6ステップで状態遷移を具体化
-- recordを「最終判断を支える最小限の情報」と定義
-- dispositionの記録存在と、根拠内容の真正性を分離
-- `MERGE_READY` recordは人間の差分・証跡レビューを置き換えないと明記
-- 許可対象を「PR headへの非force push」と具体化
-- allowlist、snapshot、intent、receiptを初出で説明
-- intentあり・receiptなしを「再要求され得る」とし、exactly-onceの限界を維持
-- 複数の短い段落を統合し、読み進めやすく調整
-
-### 判定
-
-must/highは解消。抽象的な設計解説から、実装の保証範囲と人間の確認責務が分かる記事へ改善した。
+> L307 のリンクは解決するがランディングページのため WebFetch では該当権限節を確認できず——リンク切れではなく「個別エンドポイント節は未表示（未検証）」として扱う。
 
 ---
 
-## 4. Loop 3: 転用可能性と誤用防止
+## 4. 残課題と公開可否の総合判定
 
-### レビュー結果
+### 残課題（すべて任意 / 公開ブロッカーではない）
 
-| ID | 視点 | 優先度 | 指摘 |
-|---|---|---|---|
-| L3-01 | security | high | 「権限を分離する」とだけ書くと、PRコメントとマージが同じ書き込み権限に含まれる場合もトークンスコープだけで分離可能と誤解される |
-| L3-02 | editor | medium | `main` 固有の表現は、base branch名が異なる環境への転用を妨げる |
-| L3-03 | director | medium | 一般原則は示されているが、読者が自分の環境で確認する項目へ落ちていない |
-| L3-04 | security | medium | ruleset / required review / branch protectionと、PlanGate内部の責務境界の関係を整理すると誤用を減らせる |
-| L3-05 | editor | low | 「重要な限界があります」などの予告文を削って、事実から入れる方が簡潔 |
+- **low ポリッシュ 3件**（最終レビュー）: 出典リンクのアンカー精緻化 / fail-closed 初出補足 / mermaid 図の可読性。
+- **Humanize 文体反復 2件**（Phase 1・参考情報）: 締めの語彙の単調化 / リスト導入鋳型の反復。いずれも意味を変えない局所修正。
 
-### 反映内容
+### 未検証事項
 
-- `main` を「対象ブランチ」へ一般化
-- 実行主体・権限分離に加え、ruleset、required review、branch protectionを多層防御として整理
-- 「自分の環境へ転用するときの確認項目」を7項目で追加
-- 導入順を「停止地点の定義 → 最新headへの証跡束縛 → 外部作用の集約」と提示
-- 冗長な予告文を削除
+- L307 のトークン権限記述（fine-grained token の Contents: write / Pull requests: write）は公式リファレンス参照付きだが、WebFetch で該当権限節を抽出できず「未検証（誤りとは断定せず据え置き）」。GitHub の権限スコープの通例と整合。
 
-### 判定
+### 総合判定
 
-主張を変えず、PlanGate固有の実装紹介から、他のAIエージェント運用へ転用できる設計記事へ収束した。
+**公開可（must なし・high なし・収束）。**
 
----
-
-## 5. Loop 4: マージ後の仕様確認と公開前調整
-
-### レビュー結果
-
-| ID | 視点 | 優先度 | 指摘 |
-|---|---|---|---|
-| L4-01 | security | high | PR更新とマージが同じGitHub権限に含まれるという説明は不正確。レビュー系は `Pull requests: write`、REST APIのマージは `Contents: write` |
-| L4-02 | engineer | medium | GitHubのstale approval却下と、PlanGateのhead SHA束縛の役割差が未説明 |
-| L4-03 | editor | medium | 「現在のリポジトリ設定」は時間とともに古くなるため基準日が必要 |
-| L4-04 | director | medium | topicsのClaude Code / Codex依存が、本文の汎用的な主張と一致しない |
-| L4-05 | editor | low | 冒頭のメッセージ内で想定読者と得られることが同じリストに混在 |
-
-### 反映内容
-
-- GitHub公式仕様に合わせ、レビュー系とマージ系のfine-grained token権限を分離して説明
-- PR headへのpushとREST APIマージがともにContents書き込み能力と関係するため、トークンスコープだけでは「push可・merge不可」を分離しにくい点へ主張を修正
-- GitHubのstale approval却下はリポジトリ側のマージ制約、PlanGateのhead SHA束縛は判定入力の内部整合性チェックと整理
-- PlanGateのrequired approving review設定に `2026年8月2日時点` を付記
-- topicsを `ai駆動開発 / aiagent / github / 設計 / 自動化` へ変更
-- 冒頭メッセージを「想定読者」「この記事で得られること」に分割
-
-### 判定
-
-GitHub権限モデルに関する事実誤認を解消した。記事の中心主張は維持し、外部仕様とPlanGate内部設計の境界がより明確になった。
-
----
-
-## 6. 最終レビュー
-
-### 複数視点の判定
-
-| 視点 | 判定 | コメント |
-|---|---|---|
-| director | pass | 問題提起、設計判断、限界、転用手順が一貫している |
-| editor | pass | 冒頭の情報分類、用語、基準日の明示により公開時の読みやすさが向上した |
-| engineer | pass | 状態集合、head SHA束縛、record、intent／receiptの説明が現行設計と整合 |
-| security | pass | GitHubの権限モデルを正確に記述し、責務境界と強制的な権限境界を混同していない |
-
-### 公開可否
-
-**公開可能**。
-
-- must: 0
-- high: 0
-- 中心主張: 保持
-- 過大保証: なし
-- `published`: `false` のまま
-- 記事参照リンク: 維持
-- GitHub権限モデル: 公式仕様と照合済み
+- must-high: **0**
+- 主張・8つの強調点・文体・章立て骨格・`published: false` すべて保持。
+- 残る指摘はすべて low の任意ポリッシュであり、公開をブロックしない。Humanize 指摘は review-only のため昇格させない。


### PR DESCRIPTION
## 概要

#495（GitHub権限説明の修正）がレビュー後に記事を改稿し publish-readiness が stale 化していたため、公開前に現行版へ `/review-improve-loop` を1周通し、加えて #495 の GitHub 権限主張を一次情報で検証した。

## 再レビュー結果

| ゲート | 結果 |
|---|---|
| Loop1 | 指摘6件反映（high=GitHub権限主張への出典追加 ほか） |
| Loop2 | 指摘4件反映（must/high 0で収束） |
| Humanize | **passed=true**（指摘2件・high 0） |
| Verify | must/high 0、主張・8強調点・published:false 保持 |
| publish-readiness | **blocked=false**（articleHash一致・reviewedAt=2026-08-02T03:00:03Z） |

## ★ GitHub権限主張の一次検証（レビュアーが未検証とした点）

[GitHub公式 fine-grained PAT 権限リファレンス](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)で確認:
- **PRマージ（PUT .../merge）= `Contents` write** ✓（記事の主張どおり）
- PR作成（POST .../pulls）= `Pull requests` write

push も `Contents: write` が必要 → 「pushは許可・mergeは禁止をトークンスコープだけで分離するのは困難」という論拠は**事実として成立**。ループの『未検証』フラグは WebFetch がランディングページに当たったためで、一次情報では正確。

## 検証

- `npm run check` exit 0、事実（コード断片・権限主張）保持を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)