### PR TITLE
chore(zenn): ai-merge-ready-state-machine を published:true へ（main 段）

### DIFF
--- a/articles/ai-merge-ready-state-machine.md
+++ b/articles/ai-merge-ready-state-machine.md
@@ -3,7 +3,7 @@ title: "AIにマージさせない。PRをMERGE_READYまで運ぶ状態機械の
 emoji: "🔀"
 type: "tech"
 topics: ["ai駆動開発", "aiagent", "github", "生成ai", "codereview"]
-published: false
+published: true
 ---
 
 **AIにPRの修正を任せるなら、どこまでをAIの責任にするべきでしょうか。**


### PR DESCRIPTION
## 概要

「AIにマージさせない。PRをMERGE_READYまで運ぶ状態機械の設計」の公開。**main 段（公開フロー1段目）**。本 PR マージでは Zenn deploy は発火しない（deploy は release/zenn への merge のみ）。

## 差分

`articles/ai-merge-ready-state-machine.md`: `published: false → true`（1行のみ、本文不変）

## 公開フロー（2段・本PRは1段目）

1. **本 PR**: main へ published:true 化 → 承認・マージ
2. **次段**: `scripts/sync-release-zenn.sh` で release/zenn sync PR → 承認・マージ → Zenn deploy 発火

## rate-limit

過去24h `published:false→true` 切替: **0件**（`check:zenn-pace` OK）

## 公開予定 URL

https://zenn.dev/minewo/articles/ai-merge-ready-state-machine

## レビュー・検証収束

- ChatGPT執筆 → 事実検証（コード断片・6ファイル参照すべて実装と一致）
- #495改稿（GitHub権限説明修正）→ **一次情報で再検証**（PRマージ=Contents write を GitHub公式で確認）
- /review-improve-loop 2周（#493 + #496）、Humanize passed、must/high 0
- publish-readiness: blocked=false / verified=true（articleHash一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)