### PR TITLE
docs(queue): 次期テーマ2件を補充 — review-only Humanizer 設計(8/24)・並列AIセッション事故の事後検知(9/7)

### DIFF
--- a/docs/publish-queue.md
+++ b/docs/publish-queue.md
@@ -11,7 +11,8 @@
 
 ## Queue（締切順）
 
-（現在、公開待ちのキューは空。補充は手動で行を追加）
+- **#10 (zenn) 締切 2026-08-24**: 「技術記事の"AIっぽさ"を書き換えずに検出する — review-only Humanizer の設計」（仮）。一次情報: `.claude/skills/article-humanizer-ja` の実装＋論証観点 T11〜T15＋`/review-improve-loop` での実運用実績（#459/#476/#494 系）。差別化: 市場は書き換えツール紹介ばかりで、「主張・事実・コード・URL を保護リストで守り、修正案を low/medium/high で返す」設計論は空白（theme-discovery 2026-08-10、スコア 18/20）。自己改善ループ記事（2026-07-20 公開）とのシリーズ導線を張る
+- **#11 (zenn) 締切 2026-09-07**: 「worktree 分離だけでは防げない — 並列AIセッションのGit事故を"事後検知"で機械化する」（仮）。一次情報: `scripts/check-pr-staleness.sh`＋テスト、`scripts/hooks/pre-commit|pre-push`、Round 3〜5 の実測インシデント（#404/#405 の squash 済み記事巻き戻し等、`memory/project_parallel_session_metrics.md`）。差別化: 市場は git worktree による事前分離記事が多数だが、同一 working tree での実事故観測データと検知系（staleness チェック・hooks）は空白（theme-discovery 2026-08-10、スコア 17/20）
 - #7 (zenn-book) は **2026-06-01 公開完了**（下記 Done 参照）。本文・図・cover・5系統＋ultracode レビュー完了後、release/zenn PR #350 マージで go-live
 - #9 (zenn) は「Bookを多層AIレビューで作った話」。内容は収束済み・公開可。タイミングのみ分離（Book公開→update同期→新規publish の順で間隔を空ける）
 - #2 公開時、本文「関連記事」の scope-creep 参照に下記 Done の実 Qiita URL を差し込む（相互リンク確定）


### PR DESCRIPTION
## 概要

公開キューが空だったため、theme-discovery スキル（資産棚卸し→市場照合→採点→検証）で次期テーマ 2 件を選定し、締切付きで Queue に追加する。

## 追加内容

| # | テーマ（仮） | 締切 | スコア |
|---|---|---|---|
| #10 | 技術記事の"AIっぽさ"を書き換えずに検出する — review-only Humanizer の設計 | 2026-08-24 | 18/20 |
| #11 | worktree 分離だけでは防げない — 並列AIセッションのGit事故を"事後検知"で機械化する | 2026-09-07 | 17/20 |

## 選定根拠

- **#10**: 市場は書き換えツール（AISEO 等）の紹介記事ばかりで、「主張・事実・コード・URL を保護リストで守り、修正案のみ返す」設計論は空白。一次情報は `article-humanizer-ja` スキル実装＋論証観点 T11〜T15＋review-improve-loop 実運用（#459/#476/#494 系）。公開済みの自己改善ループ記事とシリーズ導線を張れる
- **#11**: 市場は git worktree による事前分離記事が多数だが、同一 working tree の実事故観測データ＋事後検知（`check-pr-staleness.sh`・pre-commit hooks）は空白。一次情報は #404/#405 巻き戻しインシデントと Round 3〜5 実測

🤖 Generated with [Claude Code](https://claude.com/claude-code)